### PR TITLE
TECH: Update support for adding values when sending custom events to the API

### DIFF
--- a/features/analytics.mdx
+++ b/features/analytics.mdx
@@ -52,16 +52,16 @@ You can capture custom events using custom code - it's best to do this in an [Ac
   </Step>
 </Steps>
 
-**Structured payload for purchase data**
+**Structured payload for custom event data**
 
-For purchase or revenue-related events, we recommend sending properties in a controlled schema so they can be analyzed consistently. Use two optional objects inside your props:
+For custom events where you want to send a mix of numeric metrics and categorical dimensions, we recommend using a controlled schema so they can be analyzed consistently. Use two optional objects inside your props:
 
-- **payload_metrics**: A key–value object where all values are numbers (e.g. `order_value`, `revenue`, `subtotal`, `tax`).
-- **payload_dimensions**: A key–value object where all values are strings (e.g. `plan`, `bundle`, `purchase_type`, `currency`).
+- **payload_metrics**: A key–value object where all values are numbers (for example `order_value`, `revenue`, `subtotal`, `tax`, `score`, `duration_ms`).
+- **payload_dimensions**: A key–value object where all values are strings (for example `plan`, `bundle`, `purchase_type`, `currency`, `segment`, `experiment_variant`).
 
 This follows a metrics-vs-dimensions approach and gives you flexibility without locking into fixed columns. You can use your own keys as long as values match the types above.
 
-Example for a purchase completion event:
+Example for a purchase completion event using this schema:
 
 ```js
 function output(userData, helperFunctions) {

--- a/features/analytics.mdx
+++ b/features/analytics.mdx
@@ -52,6 +52,40 @@ You can capture custom events using custom code - it's best to do this in an [Ac
   </Step>
 </Steps>
 
+**Structured payload for purchase data**
+
+For purchase or revenue-related events, we recommend sending properties in a controlled schema so they can be analyzed consistently. Use two optional objects inside your props:
+
+- **payload_metrics**: A key–value object where all values are numbers (e.g. `order_value`, `revenue`, `subtotal`, `tax`).
+- **payload_dimensions**: A key–value object where all values are strings (e.g. `plan`, `bundle`, `purchase_type`, `currency`).
+
+This follows a metrics-vs-dimensions approach and gives you flexibility without locking into fixed columns. You can use your own keys as long as values match the types above.
+
+Example for a purchase completion event:
+
+```js
+function output(userData, helperFunctions) {
+  helperFunctions.trackCustomEvent('purchase_completed', {
+    payload_metrics: {
+      order_value: 99.99,
+      revenue: 89.99,
+      subtotal: 79.99,
+      tax: 10.0
+    },
+    payload_dimensions: {
+      plan: 'premium',
+      bundle: 'annual',
+      purchase_type: 'subscription',
+      currency: 'USD'
+    }
+  });
+}
+```
+
+<Tip>
+Keep `payload_metrics` values as numbers and `payload_dimensions` values as strings. You can add any keys you need within those constraints.
+</Tip>
+
 ### Custom server-side events
 
 Some events will occur somewhere other than in the Embeddable, for example a user completing a doctor's appointment.

--- a/how-to/send-data-to-embeddables.mdx
+++ b/how-to/send-data-to-embeddables.mdx
@@ -22,7 +22,7 @@ In those cases, you can [send data to the Embeddables API using a server-side re
       - `embeddable_id`: The ID of your Embeddable
       - `timestamp`: The time the event occurred (in ISO 8601 format)
       - `custom_event_name`: A name for your custom event (must be snake_case)
-      - `custom_event_props`: Any custom properties as a JSON string
+      - `custom_event_props`: Any custom properties as a JSON string. For purchase events, we recommend sending an object with `payload_metrics` (numbers) and `payload_dimensions` (strings) as described below.
       - `identifiers`: A list of key-value pairs to identify the user (e.g., email)
 
     <Tip>
@@ -60,6 +60,37 @@ In those cases, you can [send data to the Embeddables API using a server-side re
 
   </Step>
 </Steps>
+
+## Example: Purchase events with structured payload
+
+For purchase or revenue-related events, we recommend structuring `custom_event_props` as a JSON string containing:
+
+- **payload_metrics**: A key–value object where all values are numbers (e.g. `order_value`, `revenue`, `subtotal`).
+- **payload_dimensions**: A key–value object where all values are strings (e.g. `plan`, `bundle`, `purchase_type`).
+
+This follows a metrics-vs-dimensions approach and keeps your data easy to analyze. The same schema applies when tracking [custom client-side events](/features/analytics#custom-client-side-events).
+
+Example request for a purchase event:
+
+```bash
+curl -X POST https://api.embeddables.com/projects/pr_myexampleproject/events \
+  -H "X-Api-Key: rk_myexampleapikey" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "embeddable_id": "flow_myexampleflow",
+    "timestamp": "2022-01-01T00:00:00.000Z",
+    "custom_event_name": "purchase_completed",
+    "custom_event_props": "{\"payload_metrics\": {\"order_value\": 99.99, \"revenue\": 89.99}, \"payload_dimensions\": {\"plan\": \"premium\", \"bundle\": \"annual\", \"purchase_type\": \"subscription\"}}",
+    "identifiers": [
+      {
+        "key": "email",
+        "value": "\"test@test.com\""
+      }
+    ]
+  }'
+```
+
+Inside `custom_event_props`, the JSON object has numeric values under `payload_metrics` and string values under `payload_dimensions`. You can add your own keys while respecting those types.
 
 <Note>
   The API will return a 200 status code if the event was successfully created.

--- a/how-to/send-data-to-embeddables.mdx
+++ b/how-to/send-data-to-embeddables.mdx
@@ -22,7 +22,7 @@ In those cases, you can [send data to the Embeddables API using a server-side re
       - `embeddable_id`: The ID of your Embeddable
       - `timestamp`: The time the event occurred (in ISO 8601 format)
       - `custom_event_name`: A name for your custom event (must be snake_case)
-      - `custom_event_props`: Any custom properties as a JSON string. For purchase events, we recommend sending an object with `payload_metrics` (numbers) and `payload_dimensions` (strings) as described below.
+      - `custom_event_props`: Any custom properties as a JSON string. For events where you want to send structured metrics and dimensions (for example purchase events), we recommend sending an object with `payload_metrics` (numbers) and `payload_dimensions` (strings) as described below.
       - `identifiers`: A list of key-value pairs to identify the user (e.g., email)
 
     <Tip>
@@ -61,16 +61,16 @@ In those cases, you can [send data to the Embeddables API using a server-side re
   </Step>
 </Steps>
 
-## Example: Purchase events with structured payload
+## Example: Structured metrics and dimensions payload
 
-For purchase or revenue-related events, we recommend structuring `custom_event_props` as a JSON string containing:
+For events where you want to send a mix of numeric metrics and categorical dimensions, we recommend structuring `custom_event_props` as a JSON string containing:
 
-- **payload_metrics**: A key–value object where all values are numbers (e.g. `order_value`, `revenue`, `subtotal`).
-- **payload_dimensions**: A key–value object where all values are strings (e.g. `plan`, `bundle`, `purchase_type`).
+- **payload_metrics**: A key–value object where all values are numbers (for example `order_value`, `revenue`, `subtotal`).
+- **payload_dimensions**: A key–value object where all values are strings (for example `plan`, `bundle`, `purchase_type`).
 
 This follows a metrics-vs-dimensions approach and keeps your data easy to analyze. The same schema applies when tracking [custom client-side events](/features/analytics#custom-client-side-events).
 
-Example request for a purchase event:
+Example request for a purchase event using this schema:
 
 ```bash
 curl -X POST https://api.embeddables.com/projects/pr_myexampleproject/events \


### PR DESCRIPTION
- Add structured payload section to Analytics (custom client-side events)
- Add purchase events example to send-data-to-embeddables
- Recommend metrics (numbers) vs dimensions (strings) schema in both places

AFTER / BEFORE

<img width="1920" height="1041" alt="image" src="https://github.com/user-attachments/assets/ac396dad-36c5-4f6e-84c4-9767c78cdcea" />

New blocks 

/how-to/send-data-to-embeddables
<img width="1892" height="1040" alt="image" src="https://github.com/user-attachments/assets/abc2a6fd-9a18-44f0-8539-1f87d77f98f6" />

/features/analytics#custom-client-side-events
<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/1cb134b6-042f-4a03-8ccf-8a538c011b0a" />




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213213813440171