### PR TITLE
CLI asset management limitation

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -580,7 +580,7 @@ Also **compare your CLI version to the latest on npm** ([@embeddables/cli](https
 ## Current limitations
 
 - **You can’t create Embeddables** from the CLI; you can only pull and edit existing Embeddables (create new ones in the Builder).
-- **No asset upload** from the CLI yet; use the Builder for uploading images/assets.
+- **No asset management** from the CLI yet. You can't upload, browse, or manage images and other assets through the CLI. To use assets in your Embeddable, either upload them in the Builder and copy the resulting URLs into your code, or use placeholder image URLs while building locally and swap them out later.
 - **No creating new branches/experiments** from the CLI; you can connect to existing ones (`embeddables branch`, `embeddables experiments connect`).
 - **`embeddables dev` doesn’t yet work** for Embeddables that use the CMS feature; use the Builder preview or a deployed embed for those.
 - **Some edge cases** in multilingual property handling.


### PR DESCRIPTION
Expand the "No asset upload" limitation on the CLI page to clarify asset management limitations and provide workarounds.

---
<p><a href="https://cursor.com/agents?id=bc-e6359e40-2a8b-4e5b-ad76-42a9bb61fe58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6359e40-2a8b-4e5b-ad76-42a9bb61fe58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

