### PR TITLE
Add Codex (AGENTS.md) support and update CLI to v0.7.14

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.7.13** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.7.14** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -92,6 +92,7 @@ my-project/
 ├── .gitignore                # Updated to ignore .generated/ and .types/
 ├── .cursor/rules/            # Cursor AI rules (optional, from init)
 ├── .claude/                  # Claude project context (optional, from init)
+├── AGENTS.md                 # Codex context (optional, from init)
 └── embeddables/
     └── <embeddable-id>/
         ├── pages/                    # One .page.tsx file per page
@@ -118,7 +119,7 @@ my-project/
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `embeddables login`   | Log in to your Embeddables account (global).                                                                                                        |
 | `embeddables logout`  | Clear stored authentication.                                                                                                                        |
-| `embeddables init`    | Initialize from inside your project folder: creates `embeddables.json`, `.types/`, `tsconfig.json`, `embeddables/`, optional Cursor/Claude prompts. |
+| `embeddables init`    | Initialize from inside your project folder: creates `embeddables.json`, `.types/`, `tsconfig.json`, `embeddables/`, optional Cursor/Claude/Codex prompts. |
 | `embeddables upgrade` | Update the CLI to the latest stable version.                                                                                                        |
 
 ### Daily workflow
@@ -451,7 +452,7 @@ my-project/
 
 ## Using the CLI with AI
 
-The CLI is built for **AI-assisted editing**: the file layout is predictable, and `embeddables init` injects **Cursor rules** and **Claude project context** so the assistant understands Embeddable components, keys, and conventions. Use the subsections below to get the most out of Cursor, Claude, and your own prompts.
+The CLI is built for **AI-assisted editing**: the file layout is predictable, and `embeddables init` injects **Cursor rules**, **Claude project context**, and **Codex context (AGENTS.md)** so the assistant understands Embeddable components, keys, and conventions. Use the subsections below to get the most out of Cursor, Claude, Codex, and your own prompts.
 
 ### Cursor
 
@@ -474,6 +475,14 @@ When you run `embeddables init`, the CLI can also add **Claude (Claude Code / pr
 - **Re-injecting**: As with Cursor, run `embeddables init` again to recreate or refresh `.claude/` if you removed it or want the latest content.
 
 Claude works well for multi-step tasks (e.g. “add a new page and wire up the buttons”) or when you paste in the context file path at the start of a long conversation.
+
+### Codex
+
+When you run `embeddables init`, the CLI generates an **`AGENTS.md`** file at the project root:
+
+- **Where it goes**: `AGENTS.md` (project root)
+- **What it does**: Follows the OpenAI Codex convention. Contains the same Embeddables CLI context as the Cursor and Claude files (file structure, component types, conventions, etc.), so Codex has full awareness of the project when making edits.
+- **Re-injecting**: Run `embeddables init` again to regenerate or update `AGENTS.md` with the latest content from the CLI package.
 
 ### Tips and best practices for prompt writing
 
@@ -629,8 +638,8 @@ Also **compare your CLI version to the latest on npm** ([@embeddables/cli](https
   <Accordion title="What is the Workbench and how do I open it?">
     The Workbench is a debugging panel that lets you inspect user data, computed fields, actions, and navigate pages. On localhost previews from `embeddables dev`, it is shown by default; add `?workbench=false` to hide it. On non-localhost preview links, add `?workbench=true` to show it. It is served by the dev proxy and does not require a separate deploy.
   </Accordion>
-  <Accordion title="Does the CLI work with Cursor / Claude?">
-    Yes. The CLI is designed for AI-assisted editing. Running `embeddables init` can inject Cursor rules and Claude project context (from the CLI package) so the assistant understands the file layout, component types, and conventions. You can also use the built-in prompts from the CLI repo in your own rules.
+  <Accordion title="Does the CLI work with Cursor / Claude / Codex?">
+    Yes. The CLI is designed for AI-assisted editing. Running `embeddables init` injects Cursor rules (`.cursor/rules/`), Claude project context (`.claude/`), and a Codex-compatible `AGENTS.md` file so the assistant understands the file layout, component types, and conventions. You can also use the built-in prompts from the CLI repo in your own rules.
   </Accordion>
   <Accordion title="How do I get the latest CLI version?">
     Run `embeddables upgrade`. You can check the current version with `embeddables -v`.

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -16,10 +16,10 @@ Check your version: `embeddables -v`
 ### Features
 
 - **Codex (AGENTS.md) support** — `embeddables init` now generates an `AGENTS.md` file at the project root, following the OpenAI Codex convention. This gives Codex the same Embeddables CLI context that Cursor and Claude already receive.
-- **Condition `id` now required** — The `id` field on conditions is now required (previously optional). Use the `cond_` prefix + 10 digits format (e.g. `cond_1234567890`), consistent with other ID conventions. Existing conditions without IDs will need one added.
 
 ### Bug Fixes
 
+- **Condition `id` now required** — The `id` field on conditions is now required (previously optional). Use the `cond_` prefix + 10 digits format (e.g. `cond_1234567890`), consistent with other ID conventions. Existing conditions without IDs will need one added.
 - **Case-insensitive sorting in CLI lists** — Lists of embeddables, projects, and experiments shown in interactive prompts now sort case-insensitively using `localeCompare`. Previously, uppercase names (e.g. "CLI") could sort before lowercase ones (e.g. "count").
 
 </Update>

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,19 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.7.14 — 22 February 2026">
+
+### Features
+
+- **Codex (AGENTS.md) support** — `embeddables init` now generates an `AGENTS.md` file at the project root, following the OpenAI Codex convention. This gives Codex the same Embeddables CLI context that Cursor and Claude already receive.
+- **Condition `id` now required** — The `id` field on conditions is now required (previously optional). Use the `cond_` prefix + 10 digits format (e.g. `cond_1234567890`), consistent with other ID conventions. Existing conditions without IDs will need one added.
+
+### Bug Fixes
+
+- **Case-insensitive sorting in CLI lists** — Lists of embeddables, projects, and experiments shown in interactive prompts now sort case-insensitively using `localeCompare`. Previously, uppercase names (e.g. "CLI") could sort before lowercase ones (e.g. "count").
+
+</Update>
+
 <Update label="v0.7.13 — 22 February 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary
This PR updates the CLI documentation and changelog to reflect v0.7.14, which introduces support for OpenAI Codex through an auto-generated `AGENTS.md` file, alongside existing Cursor and Claude integrations.

## Key Changes

- **Version bump**: Updated CLI version from 0.7.13 to 0.7.14 in the main documentation
- **Codex integration**: 
  - Added `AGENTS.md` to the project structure documentation as an optional file generated during `embeddables init`
  - Created a new "Codex" subsection under "Using the CLI with AI" explaining the `AGENTS.md` file, its purpose, and how to regenerate it
  - Updated the introductory paragraph to mention Codex alongside Cursor and Claude
- **Documentation updates**:
  - Updated the `embeddables init` command description to include "Codex prompts"
  - Updated the FAQ accordion title and answer to include Codex support
- **Changelog entry**: Added v0.7.14 release notes documenting:
  - Codex (AGENTS.md) support feature
  - Condition `id` field now required with specific format
  - Bug fix for case-insensitive sorting in CLI lists

## Implementation Details

The `AGENTS.md` file follows OpenAI's Codex convention and contains the same Embeddables CLI context as the existing Cursor rules (`.cursor/rules/`) and Claude project context (`.claude/`) files, ensuring consistent AI assistant awareness across all three platforms.

https://claude.ai/code/session_01JoDh2JF1PMKecAmh5dnXmT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API changes in this PR.
> 
> **Overview**
> Updates the CLI docs to **v0.7.14** and documents new **Codex support** via an `AGENTS.md` file generated by `embeddables init` (added to the project structure, AI section, and FAQ alongside Cursor/Claude).
> 
> Adds a `v0.7.14` changelog entry covering `AGENTS.md` generation plus behavior changes: **conditions now require an `id`** and interactive CLI lists now **sort case-insensitively**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a8611c6781e2c02169f370d516090c44491a15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->