### PR TITLE
CLI docs update

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -139,6 +139,12 @@ my-project/
 | ------------------- | ------------------------------------------------------------------------------------------------- |
 | `embeddables build` | Compile TSX → JSON only (no upload). Used automatically by `save` unless you pass `--skip-build`. |
 
+### Debugging
+
+| Command                | Description                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| `embeddables inspect`  | Fetch an embeddable from the cloud, reverse-compile to TSX, rebuild to JSON, and compare the two — to identify round-trip compile issues. |
+
 ---
 
 ### Command options (reference)
@@ -411,6 +417,69 @@ my-project/
         </tr>
       </tbody>
     </table>
+  </Accordion>
+  <Accordion title="embeddables inspect">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Embeddable ID to inspect (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--version &lt;version&gt;</code>
+          </td>
+          <td>
+            Version to inspect — a number or <code>"latest"</code> (default: <code>latest</code>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-b, --branch &lt;branch_id&gt;</code>
+          </td>
+          <td>Branch ID to fetch the embeddable from.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-f, --fix</code>
+          </td>
+          <td>
+            Remove components with missing required props instead of erroring (default: on).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-e, --engine &lt;url&gt;</code>
+          </td>
+          <td>
+            Engine origin (default: <code>https://engine.embeddables.com</code>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>--bypass-auth</code>
+          </td>
+          <td>
+            Skip login check. Use in CI or cloud AI environments where interactive auth is not possible (e.g. <code>embeddables inspect -i &lt;id&gt; --bypass-auth</code>).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Output files are written to `embeddables/<id>/`:
+
+    - `.generated/embeddable-original.json` — raw JSON from the engine
+    - `.generated/embeddable-rebuilt.json` — JSON after the round-trip through React
+    - `pages/`, `styles/`, `computed-fields/`, `actions/` — the intermediate React/CSS/JS files
+
   </Accordion>
   <Accordion title="embeddables experiments connect">
     <table>

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -15,12 +15,16 @@ Check your version: `embeddables -v`
 
 ### Features
 
-- **Codex (AGENTS.md) support** — `embeddables init` now generates an `AGENTS.md` file at the project root, following the OpenAI Codex convention. This gives Codex the same Embeddables CLI context that Cursor and Claude already receive.
+- **`embeddables inspect` command** — New debugging command that fetches an embeddable from the cloud, reverse-compiles it to React/TSX, rebuilds it back to JSON, and compares the two outputs side-by-side. Ideal for reproducing and diagnosing round-trip compile issues. Output files are written to `embeddables/<id>/` for easy inspection. Usage: `embeddables inspect -i <embeddableId>`.
 
-### Bug Fixes
+### Improvements
 
-- **Condition `id` now required** — The `id` field on conditions is now required (previously optional). Use the `cond_` prefix + 10 digits format (e.g. `cond_1234567890`), consistent with other ID conventions. Existing conditions without IDs will need one added.
-- **Case-insensitive sorting in CLI lists** — Lists of embeddables, projects, and experiments shown in interactive prompts now sort case-insensitively using `localeCompare`. Previously, uppercase names (e.g. "CLI") could sort before lowercase ones (e.g. "count").
+- **`inspect` requires authentication** — The `inspect` command now requires login (consistent with other cloud commands). For CI environments or cloud AI agents that cannot go through interactive login, the hidden `--bypass-auth` flag skips authentication: `embeddables inspect -i <id> --bypass-auth`.
+- **Consumer project AI rules updated** — The Embeddables CLI prompt injected into consumer projects (`.cursor/rules/`, `.claude/`, `AGENTS.md`) now includes clearer guidance on the `inspect` command and an improved CLI command reference table.
+
+### Chores
+
+- **Documentation update workflow** — Multiple improvements to the automated CI workflow that updates these docs on release: fixed permission modes, adjusted workflow triggers, and added a version input for more reliable runs.
 
 </Update>
 


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: manual run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (no runtime or API behavior changes), with minimal risk beyond potential drift from the actual CLI flags/behavior.
> 
> **Overview**
> Updates the CLI docs to include the new **`embeddables inspect`** debugging command, including its purpose (round-trip JSON↔TSX comparison), CLI options, and the generated output files written under `embeddables/<id>/`.
> 
> Updates the v0.7.14 changelog entry to call out `inspect`, note its authentication requirement, and document the hidden `--bypass-auth` flag for non-interactive environments, plus a brief note about refreshed AI-injected rules/reference tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 923e4e78858980ff5127ed0044ee65f9ee9efbd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->