### PR TITLE
CLI docs update v0.7.15

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -104,7 +104,9 @@ my-project/
         ├── metadata.json            # Title and basic info
         └── .generated/              # Compiled JSON (used by dev/save; avoid editing)
             ├── embeddable.json      # Current compiled output
-            └── embeddable-<branch>@<version>.json   # Saved versions (for comparison)
+            ├── embeddable-<branch>@<version>.json   # Saved versions (for comparison)
+            ├── embeddable-original.json             # (inspect) Raw JSON fetched from engine
+            └── embeddable-rebuilt.json              # (inspect) JSON after round-trip through React
 ```
 
 - **Pages**: `pages/<pageKey>.page.tsx` — React components built from Embeddable primitives.
@@ -138,6 +140,12 @@ my-project/
 | Command             | Description                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
 | `embeddables build` | Compile TSX → JSON only (no upload). Used automatically by `save` unless you pass `--skip-build`. |
+
+### Debugging
+
+| Command               | Description                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| `embeddables inspect` | Fetch an Embeddable from the cloud, reverse-compile it to React, rebuild it to JSON, and compare the two — shows exactly which top-level keys differ. Useful for diagnosing round-trip compile issues. |
 
 ---
 
@@ -411,6 +419,72 @@ my-project/
         </tr>
       </tbody>
     </table>
+  </Accordion>
+  <Accordion title="embeddables inspect">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Embeddable ID to inspect (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--version &lt;version&gt;</code>
+          </td>
+          <td>
+            Version to fetch (number or <code>"latest"</code>; default:{" "}
+            <code>"latest"</code>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-b, --branch &lt;branch_id&gt;</code>
+          </td>
+          <td>Embeddable branch ID to inspect.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-f, --fix</code>
+          </td>
+          <td>
+            Remove components missing required props instead of erroring
+            (enabled by default).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-e, --engine &lt;url&gt;</code>
+          </td>
+          <td>
+            Engine origin (default:{" "}
+            <code>https://engine.embeddables.com</code>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>--bypass-auth</code>
+          </td>
+          <td>
+            Skip authentication check. Intended for CI environments and cloud
+            AI agents that cannot interactively log in.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Output files are written to `embeddables/<id>/`:
+
+    - `.generated/embeddable-original.json` — raw JSON fetched from the engine
+    - `.generated/embeddable-rebuilt.json` — JSON after round-tripping through React
+    - `pages/`, `styles/`, `computed-fields/`, `actions/` — the intermediate React/CSS/JS files
   </Accordion>
   <Accordion title="embeddables experiments connect">
     <table>

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -15,12 +15,17 @@ Check your version: `embeddables -v`
 
 ### Features
 
+- **`embeddables inspect` command** — New debugging command that fetches an Embeddable from the engine, reverse-compiles it to React/CSS/JS, rebuilds it back to JSON, and reports which top-level keys differ. Useful for diagnosing round-trip compile issues without a full local project setup. Run `embeddables inspect -i <embeddableId>`. Output files are written to `embeddables/<id>/` for further analysis.
 - **Codex (AGENTS.md) support** — `embeddables init` now generates an `AGENTS.md` file at the project root, following the OpenAI Codex convention. This gives Codex the same Embeddables CLI context that Cursor and Claude already receive.
 
 ### Bug Fixes
 
 - **Condition `id` now required** — The `id` field on conditions is now required (previously optional). Use the `cond_` prefix + 10 digits format (e.g. `cond_1234567890`), consistent with other ID conventions. Existing conditions without IDs will need one added.
 - **Case-insensitive sorting in CLI lists** — Lists of embeddables, projects, and experiments shown in interactive prompts now sort case-insensitively using `localeCompare`. Previously, uppercase names (e.g. "CLI") could sort before lowercase ones (e.g. "count").
+
+### Improvements
+
+- **`inspect` requires login** — `embeddables inspect` now requires authentication by default, consistent with other commands. A hidden `--bypass-auth` flag is available for CI environments and cloud AI agents that cannot interactively authenticate (e.g. `embeddables inspect -i <id> --bypass-auth`).
 
 </Update>
 


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.7.15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; no runtime or behavior changes to the CLI itself.
> 
> **Overview**
> Documentation update adds the new **`embeddables inspect` debugging command** to the CLI reference, including its purpose (round-trip JSON React comparison), flags (`--version`, `--branch`, `--fix`, `--engine`, `--bypass-auth`), and the additional `.generated/` output artifacts (`embeddable-original.json` / `embeddable-rebuilt.json`).
> 
> Changelog entry is updated to announce `inspect` and notes an improvement that it **requires login by default**, with a hidden `--bypass-auth` option for CI/agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a0df77aa1fe7697ad69cf275e4b119ece56a19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->