### PR TITLE
CLI docs update v0.7.16

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -203,14 +203,6 @@ my-project/
         </tr>
         <tr>
           <td>
-            <code>--version [number]</code>
-          </td>
-          <td>
-            Pull a specific version. Omit the flag entirely to pull the latest automatically. Pass <code>--version</code> with no value to open the interactive version selector. Pass <code>--version &lt;number&gt;</code> to pull a specific version (e.g. <code>--version 47</code>).
-          </td>
-        </tr>
-        <tr>
-          <td>
             <code>-b, --branch &lt;branch_id&gt;</code>
           </td>
           <td>Pull a specific branch.</td>

--- a/cli.mdx
+++ b/cli.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.7.15** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.7.16** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -199,6 +199,14 @@ my-project/
           <td>
             Output path for compiled JSON (default:{" "}
             <code>embeddables/&lt;id&gt;/.generated/embeddable.json</code>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>--version [number]</code>
+          </td>
+          <td>
+            Pull a specific version. Omit the flag entirely to pull the latest automatically. Pass <code>--version</code> with no value to open the interactive version selector. Pass <code>--version &lt;number&gt;</code> to pull a specific version (e.g. <code>--version 47</code>).
           </td>
         </tr>
         <tr>

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -13,17 +13,9 @@ Check your version: `embeddables -v`
 
 <Update label="v0.7.16 — 22 February 2026">
 
-### Features
-
-- **`embeddables pull` defaults to latest** — Running `embeddables pull` with no flags now pulls the latest version immediately, without prompting. To choose a version interactively, pass `--version` with no value (`embeddables pull --version`). To pull a specific version, pass `--version <number>` (e.g. `embeddables pull --version 47`). Previously, omitting `--version` would open the interactive version selector.
-
 ### Bug Fixes
 
 - **Reverse compiler: global component cross-location `parent_id`** — Fixed a round-trip bug where a global component with `_location` pointing to one group (e.g. `before_components`) but `parent_id` pointing to a component in a different location group (e.g. `before_page`) was orphaned during reverse compilation. Components are now grouped by following their parent chain rather than their own `_location`, keeping the component tree intact in a single TSX file.
-
-### Improvements
-
-- **`embeddables inspect` now requires login** — The `inspect` command now requires authentication by default (scoped to your project's embeddables). A hidden `--bypass-auth` flag is available for AI tooling or CI environments that need to skip the login check.
 
 </Update>
 

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,22 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.7.16 — 22 February 2026">
+
+### Features
+
+- **`embeddables pull` defaults to latest** — Running `embeddables pull` with no flags now pulls the latest version immediately, without prompting. To choose a version interactively, pass `--version` with no value (`embeddables pull --version`). To pull a specific version, pass `--version <number>` (e.g. `embeddables pull --version 47`). Previously, omitting `--version` would open the interactive version selector.
+
+### Bug Fixes
+
+- **Reverse compiler: global component cross-location `parent_id`** — Fixed a round-trip bug where a global component with `_location` pointing to one group (e.g. `before_components`) but `parent_id` pointing to a component in a different location group (e.g. `before_page`) was orphaned during reverse compilation. Components are now grouped by following their parent chain rather than their own `_location`, keeping the component tree intact in a single TSX file.
+
+### Improvements
+
+- **`embeddables inspect` now requires login** — The `inspect` command now requires authentication by default (scoped to your project's embeddables). A hidden `--bypass-auth` flag is available for AI tooling or CI environments that need to skip the login check.
+
+</Update>
+
 <Update label="v0.7.15 — 22 February 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.7.16