### PR TITLE
CLI docs update v0.7.17

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.7.16** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.7.17** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -191,6 +191,14 @@ my-project/
             <code>-i, --id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID to pull (skips interactive selection).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--version [number]</code>
+          </td>
+          <td>
+            Version to pull. Omit a value (<code>--version</code>) to open an interactive version selector. Pass a number (<code>--version 47</code>) to pull a specific version. Without this flag, <code>pull</code> defaults to the latest version.
+          </td>
         </tr>
         <tr>
           <td>

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,14 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.7.17 — 22 February 2026">
+
+### Improvements
+
+- **`embeddables pull` defaults to latest version** — Running `embeddables pull` without `--version` now pulls the latest version automatically, skipping the version-selection prompt. To choose a version interactively, use `embeddables pull --version`; to pull a specific version, pass a number: `embeddables pull --version 47`.
+
+</Update>
+
 <Update label="v0.7.16 — 22 February 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.7.17