### PR TITLE
CLI docs update v0.7.19

### DIFF
--- a/cli.mdx
+++ b/cli.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.7.18** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.7.19** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -89,7 +89,7 @@ my-project/
 ├── embeddables.json          # Project ID and org (from init)
 ├── tsconfig.json             # TypeScript/JSX config (created by init, or patched to add type paths if it already exists)
 ├── .types/                   # Type stubs for editor autocomplete (no npm install needed)
-├── .gitignore                # Updated to ignore .generated/ and .types/
+├── .gitignore                # Updated to ignore .generated/ and node_modules/
 ├── .cursor/rules/            # Cursor AI rules (optional, from init)
 ├── .claude/                  # Claude project context (optional, from init)
 ├── AGENTS.md                 # Codex context (optional, from init)

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,16 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.7.19 — 23 February 2026">
+
+### Bug Fixes
+
+- **`embeddables dev` no longer loops when fixing duplicate option IDs** — Fixed an infinite rebuild loop in dev mode triggered when an `OptionSelector` had duplicate button IDs. The fix routine now uses targeted text replacements instead of full Babel code generation, so files are only written when content actually changes. Duplicate ID detection also now covers const-referenced button arrays (e.g. `buttons={someButtons}`), not just inline arrays.
+- **TypeScript: `props` property now included in generated component types** — The `Props<T>` type emitted into `.types/components.d.ts` by `embeddables init` was missing a `props` field, causing errors like `Property 'props' does not exist on type 'Props<FileUpload>'`. A `props?: Record<string, any>` property is now included.
+- **`embeddables init` no longer duplicates `.gitignore` entries** — Running `embeddables init` more than once used to append a new `# Embeddables` block each time. It now replaces the existing block in-place. The generated block also adds `node_modules/` and no longer unnecessarily includes `**/.types/`.
+
+</Update>
+
 <Update label="v0.7.18 — 22 February 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.7.19