### PR TITLE
CLI docs update v0.8.0

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.7.19** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.8.1** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -21,10 +21,6 @@ Check your version: `embeddables -v`
 
 - **ESC key now consistently quits all CLI prompts** — Previously, pressing ESC during interactive prompts (e.g. the email input in `embeddables login`, the OTP code entry, or the lint-fix confirmation in `embeddables build`) would silently skip the prompt and continue execution. ESC now reliably exits the process across all prompt types, including auto-complete prompts that previously resolved with the highlighted value instead of aborting.
 
-### Improvements
-
-- **`embeddables save` — improved branch display** — `getBranchFromConfig` now returns both `_branch_id` and `_branch_name`, providing clearer branch identification in save output. Proxy server startup logs are also simplified to show only essential information.
-
 ### Chores
 
 - **`prepublishOnly` build script** — `npm publish` now automatically runs the TypeScript build step before publishing, preventing accidental releases with stale `dist/` output.

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,26 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.8.1 — 23 February 2026">
+
+### Features
+
+- **Delightful CLI output overhaul** — All commands now use animated spinners (via [ora](https://github.com/sindresorhus/ora)), compact tabular output, and concise formatting. Success moments display green boxed messages; grey info boxes show context (Embeddable ID, branch, version). Verbose file listings are consolidated into summary counts. Warnings and errors now use symbols (⚠ / ✖) instead of text badges.
+
+### Bug Fixes
+
+- **ESC key now consistently quits all CLI prompts** — Previously, pressing ESC during interactive prompts (e.g. the email input in `embeddables login`, the OTP code entry, or the lint-fix confirmation in `embeddables build`) would silently skip the prompt and continue execution. ESC now reliably exits the process across all prompt types, including auto-complete prompts that previously resolved with the highlighted value instead of aborting.
+
+### Improvements
+
+- **`embeddables save` — improved branch display** — `getBranchFromConfig` now returns both `_branch_id` and `_branch_name`, providing clearer branch identification in save output. Proxy server startup logs are also simplified to show only essential information.
+
+### Chores
+
+- **`prepublishOnly` build script** — `npm publish` now automatically runs the TypeScript build step before publishing, preventing accidental releases with stale `dist/` output.
+
+</Update>
+
 <Update label="v0.7.19 — 23 February 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.8.0