### PR TITLE
CLI docs update v0.8.2

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.8.1** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.8.2** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -15,7 +15,7 @@ Check your version: `embeddables -v`
 
 ### Bug Fixes
 
-- **Reverse compiler: `htmlToJSXChildren` no longer hangs on `<!DOCTYPE>` or XML processing instructions** — Fixed an infinite loop in the HTML→JSX conversion function triggered when component HTML content begins with a declaration tag such as `<!DOCTYPE html>` or a processing instruction like `<?xml version="1.0"?>`. These non-element tags are now skipped cleanly. A secondary guard was also added so the parser always advances past any `<` character it cannot match, preventing the loop from stalling regardless of the malformed input.
+— Fixed an infinite loop in the HTML→JSX conversion function triggered when component HTML content begins with a declaration tag such as `<!DOCTYPE html>` or a processing instruction like `<?xml version="1.0"?>`. These non-element tags are now skipped cleanly. A secondary guard was also added so the parser always advances past any `<` character it cannot match, preventing the loop from stalling regardless of the malformed input.
 
 </Update>
 

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,14 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.8.2 — 23 February 2026">
+
+### Bug Fixes
+
+- **Reverse compiler: `htmlToJSXChildren` no longer hangs on `<!DOCTYPE>` or XML processing instructions** — Fixed an infinite loop in the HTML→JSX conversion function triggered when component HTML content begins with a declaration tag such as `<!DOCTYPE html>` or a processing instruction like `<?xml version="1.0"?>`. These non-element tags are now skipped cleanly. A secondary guard was also added so the parser always advances past any `<` character it cannot match, preventing the loop from stalling regardless of the malformed input.
+
+</Update>
+
 <Update label="v0.8.1 — 23 February 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.8.2