### PR TITLE
CLI docs update v0.8.3

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.8.2** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.8.3** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,15 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.8.3 — 23 February 2026">
+
+### Bug Fixes
+
+- **`embeddables pull` now works with project slugs** — Previously, passing a project slug (e.g. `cursor-telehealth`) as the Embeddable ID could fail with `"JSON object requested, multiple (or no) rows returned"`. The metadata lookup now uses `maybeSingle()` so zero results are handled gracefully, and the CLI retries the lookup with the actual flow ID returned by the engine when the user-provided ID yields no match.
+- **Automatic Embeddable detection no longer triggers falsely in directories named `embeddables/`** — `inferEmbeddableFromCwd()` previously matched any directory whose parent was named `embeddables`, causing false positives when users kept projects in a folder called `embeddables/` (e.g. `~/embeddables/cursor-telehealth/`). The function now checks for an `embeddables.json` config file before treating a directory as an Embeddable project root.
+
+</Update>
+
 <Update label="v0.8.2 — 23 February 2026">
 
 ### Bug Fixes

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -15,7 +15,6 @@ Check your version: `embeddables -v`
 
 ### Bug Fixes
 
-- **`embeddables pull` now works with project slugs** — Previously, passing a project slug (e.g. `cursor-telehealth`) as the Embeddable ID could fail with `"JSON object requested, multiple (or no) rows returned"`. The metadata lookup now uses `maybeSingle()` so zero results are handled gracefully, and the CLI retries the lookup with the actual flow ID returned by the engine when the user-provided ID yields no match.
 - **Automatic Embeddable detection no longer triggers falsely in directories named `embeddables/`** — `inferEmbeddableFromCwd()` previously matched any directory whose parent was named `embeddables`, causing false positives when users kept projects in a folder called `embeddables/` (e.g. `~/embeddables/cursor-telehealth/`). The function now checks for an `embeddables.json` config file before treating a directory as an Embeddable project root.
 
 </Update>


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.8.3