### PR TITLE
Cli changelog icon

### DIFF
--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -2,7 +2,7 @@
 title: "CLI Changelog"
 sidebarTitle: "Changelog"
 description: "Version history for the Embeddables CLI (@embeddables/cli)"
-icon: "terminal"
+icon: "list-timeline"
 ---
 
 Install or upgrade: `npm install -g @embeddables/cli`


### PR DESCRIPTION
Update the CLI Changelog icon to `list-timeline` to distinguish it from the CLI Overview and better represent a changelog.

---
<p><a href="https://cursor.com/agents/bc-6ccf1424-6513-4ba7-a2f9-64a4f255e8a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ccf1424-6513-4ba7-a2f9-64a4f255e8a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

