### PR TITLE
CLI docs update v0.9.0

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -414,6 +414,14 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
+            <code>-p, --preserve</code>
+          </td>
+          <td>
+            Preserve component order during forward compilation (default: off). Use when you want to keep existing component order for comparison purposes.
+          </td>
+        </tr>
+        <tr>
+          <td>
             <code>-e, --engine &lt;url&gt;</code>
           </td>
           <td>

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.8.3** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.9.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,22 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.9.0 — 24 February 2026">
+
+### Features
+
+- **`embeddables inspect --preserve`** — The `inspect` command now accepts a `--preserve` flag to maintain component order during forward compilation. Previously `inspect` always preserved order; it now defaults to `false` (standard compilation order), and you can opt in with `--preserve` when you want to keep existing order for comparison purposes.
+
+### Improvements
+
+- **Embeddable context info box across all commands** — `build`, `dev`, `pull`, and `save` now display a consistent info box showing the Embeddable title, ID, branch, and version at the start of each command, replacing the previous plain `ID: …` line in `dev` and varying formats in other commands.
+- **CLI help output overhauled** — `embeddables --help` now uses Shopify CLI-style formatting with color, icons, and grouped sections for a cleaner, more readable experience.
+- **`embeddables init` output polished** — The initialization header, success messages, and next-steps box have been updated: the success box now shows project title and ID; the next-steps sequence is now Pull → Run locally → Save (the Login step was removed since login is required before `init`); a prominent yellow beta warning box is shown at the end; and the docs link is included in the next-steps box.
+- **Trailing gap after all commands** — All commands (`login`, `logout`, `build`, `pull`, `save`, `inspect`, `builder open`, `experiments connect`) now consistently print a trailing blank line for cleaner terminal output.
+- **Sentry exception enrichment** — Error reports now include descriptive labels, `CompileError` file/line/column metadata, and additional tags (`versionNumber`, `cliVersion`, entity name tags alongside IDs) for faster debugging of production issues.
+
+</Update>
+
 <Update label="v0.8.3 — 23 February 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.9.0