### PR TITLE
CLI docs update v0.9.3

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.9.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.9.3** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,18 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.9.3 — 24 February 2026">
+
+### Improvements
+
+- **Richer error output with code frames** — Compile errors in `build`, `dev`, `inspect`, and `save` now display a highlighted code frame showing the surrounding source lines, a caret pointing to the exact column, and the file path and line number. Errors are written to `stderr` for consistent terminal integration.
+
+### Chores
+
+- **Sentry distributed tracing for all commands** — All CLI commands are now instrumented with Sentry spans (child spans for key operations) and custom counter/distribution metrics. This internal observability work enables detailed performance profiling and faster diagnosis of production issues, with no user-visible changes.
+
+</Update>
+
 <Update label="v0.9.0 — 24 February 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.9.3