### PR TITLE
CLI docs update v0.9.4

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.9.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.9.4** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,14 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.9.4 — 24 February 2026">
+
+### Chores
+
+- **npm package README links updated** — The "Getting Started" link in the npm package README has been replaced with direct links to [Building with AI](https://docs.embeddables.com/cli/ai) and [Troubleshooting](https://docs.embeddables.com/cli/troubleshooting) for better navigation. The beta notice was also tightened to emphasise checking the diff before saving.
+
+</Update>
+
 <Update label="v0.9.0 — 24 February 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.9.4