### PR TITLE
Embed code mismatch between web app and documentation

### DIFF
--- a/how-to/embed-code-2-0.mdx
+++ b/how-to/embed-code-2-0.mdx
@@ -6,7 +6,7 @@ description: "How to install the new embed code and upgrade the Stripe component
 The Embeddables new Embed Code 2.0 is **now available in beta**.
 
 <Warning>
-  The old Embed Code will be **deprecated on Monday November 17th, 2025**.
+  The old Embed Code will be **deprecated on February 28th, 2026**.
 </Warning>
 
 ## The new Embed Code 2.0
@@ -18,49 +18,7 @@ The Embeddables new Embed Code 2.0 is **now available in beta**.
   embedding.
 </Tip>
 
-```javascript
-<script>
-window.initEmbeddables = () => {
-  // Get the engine domain from the URL parameters
-  const engineDomain =
-    new URL(window.location.href).searchParams.get('embeddables_engine_domain') ||
-    'engine.embeddables.com'
-  const urlRoot = engineDomain.startsWith('http') ? engineDomain : 'https://' + engineDomain
-
-  // Inject the bundle script dynamically
-  const script = document.createElement('script')
-  script.src = `${urlRoot}/bundle.js`
-  document.head.appendChild(script)
-
-  const initializeEmbeddables = function () {
-    const allUserData = JSON.parse(localStorage.getItem('SavvyFormUserData') || '{}')
-    const embeddablesToLoad = [...document.querySelectorAll('savvy, embeddable')].map((el) => {
-      const attrs = Object.fromEntries([...el.attributes].map((a) => [a.name, a.value]))
-      const flowId = attrs.id
-      if (flowId && allUserData[flowId]) {
-        attrs.userData = Object.fromEntries(Object.entries(allUserData[flowId]||{}).filter(([sk])=>sk==='current_page_id'||sk.startsWith('split_')))
-      }
-      return attrs
-    })
-    const originUrl = window.location.href
-    const url =
-      `${urlRoot}/init?load=` +
-      encodeURIComponent(JSON.stringify({ embeddablesToLoad, originUrl }))
-
-    fetch(url)
-      .then((res) => res.json())
-      .then((response) => eval('(' + response.init_js + ')(response.embeddables_data)'))
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initializeEmbeddables)
-  } else {
-    initializeEmbeddables()
-  }
-}
-window.initEmbeddables()
-</script>
-```
+To get the Embed Code, head to your Embeddable in the [Embeddable Web App](https://app.embeddables.com/), and click on the Embed button in the top-right corner.
 
 ### The BODY script
 
@@ -75,7 +33,7 @@ window.initEmbeddables()
 <Steps>
   
   <Step title="Grab the new embed code">
-    Copy the `<HEAD>` script from above.
+    In the [Embeddable Web App](https://app.embeddables.com/), open your Embeddable and click the Embed button in the top-right corner to get the HEAD script.
   </Step>
 
   <Step title="Replace the old embed code with the new one">

--- a/how-to/embed-code-2-0.mdx
+++ b/how-to/embed-code-2-0.mdx
@@ -33,7 +33,7 @@ To get the Embed Code, head to your Embeddable in the [Embeddables Web App](http
 <Steps>
   
   <Step title="Grab the new embed code">
-    In the [Embeddable Web App](https://app.embeddables.com/), open your Embeddable and click the Embed button in the top-right corner to get the HEAD script.
+    In the [Embeddables Web App](https://app.embeddables.com/), open your Embeddable and click the Embed button in the top-right corner to get the HEAD script.
   </Step>
 
   <Step title="Replace the old embed code with the new one">

--- a/how-to/embed-code-2-0.mdx
+++ b/how-to/embed-code-2-0.mdx
@@ -18,7 +18,7 @@ The Embeddables new Embed Code 2.0 is **now available in beta**.
   embedding.
 </Tip>
 
-To get the Embed Code, head to your Embeddable in the [Embeddable Web App](https://app.embeddables.com/), and click on the Embed button in the top-right corner.
+To get the Embed Code, head to your Embeddable in the [Embeddables Web App](https://app.embeddables.com/), and click on the Embed button in the top-right corner.
 
 ### The BODY script
 


### PR DESCRIPTION
### Changes
- Remove embed code from docs
- Change deprecation date
<img width="859" height="283" alt="Screenshot from 2026-02-25 10-25-09" src="https://github.com/user-attachments/assets/9c479c63-3645-4bbd-a7b1-661f057fd6b2" />
<img width="856" height="455" alt="Screenshot from 2026-02-25 10-25-19" src="https://github.com/user-attachments/assets/51175355-cad0-41a0-9633-03b2375e40dc" />

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/embeddables/embeddables/editor/fix%2Fembed-code-missmatch?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213379856641975