### PR TITLE
Cli version flag

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -58,7 +58,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-p, --project-id &lt;id&gt;</code>
+            <code>-p, &#45;&#45;project-id &lt;id&gt;</code>
           </td>
           <td>
             Set project ID (if logged in, you can pick from a list instead).
@@ -66,7 +66,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-y, --yes</code>
+            <code>-y, &#45;&#45;yes</code>
           </td>
           <td>Skip prompts and use defaults.</td>
         </tr>
@@ -84,21 +84,21 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID to pull (skips interactive selection).</td>
         </tr>
         <tr>
           <td>
-            <code>--version [number]</code>
+            <code>&#45;&#45;version [number]</code>
           </td>
           <td>
-            Version to pull. Omit a value (<code>--version</code>) to open an interactive version selector. Pass a number (<code>--version 47</code>) to pull a specific version. Without this flag, <code>pull</code> defaults to the latest version.
+            Version to pull. Omit a value (<code>&#45;&#45;version</code>) to open an interactive version selector. Pass a number (<code>&#45;&#45;version 47</code>) to pull a specific version. Without this flag, <code>pull</code> defaults to the latest version.
           </td>
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            <code>-o, &#45;&#45;out &lt;path&gt;</code>
           </td>
           <td>
             Output path for compiled JSON (default:{" "}
@@ -107,13 +107,13 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            <code>-b, &#45;&#45;branch &lt;branch_id&gt;</code>
           </td>
           <td>Pull a specific branch.</td>
         </tr>
         <tr>
           <td>
-            <code>-f, --fix</code>
+            <code>-f, &#45;&#45;fix</code>
           </td>
           <td>
             Remove components with missing required props instead of erroring.
@@ -121,7 +121,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-p, --preserve</code>
+            <code>-p, &#45;&#45;preserve</code>
           </td>
           <td>Preserve component order in config (see note below).</td>
         </tr>
@@ -139,13 +139,13 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID (prompt if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>-p, --pages &lt;glob&gt;</code>
+            <code>-p, &#45;&#45;pages &lt;glob&gt;</code>
           </td>
           <td>
             Custom pages glob (default:{" "}
@@ -154,13 +154,13 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            <code>-o, &#45;&#45;out &lt;path&gt;</code>
           </td>
           <td>Output path for compiled JSON.</td>
         </tr>
         <tr>
           <td>
-            <code>-L, --local</code>
+            <code>-L, &#45;&#45;local</code>
           </td>
           <td>
             Use local engine (<code>http://localhost:8787</code>) instead of
@@ -169,16 +169,16 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-e, --engine &lt;url&gt;</code>
+            <code>-e, &#45;&#45;engine &lt;url&gt;</code>
           </td>
           <td>
             Engine origin (default: <code>https://engine.embeddables.com</code>;
-            overridden by <code>--local</code>).
+            overridden by <code>&#45;&#45;local</code>).
           </td>
         </tr>
         <tr>
           <td>
-            <code>--port &lt;n&gt;</code>
+            <code>&#45;&#45;port &lt;n&gt;</code>
           </td>
           <td>
             Dev proxy port (default: <code>3000</code>). If in use, CLI tries
@@ -187,7 +187,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>--overrideRoute &lt;path&gt;</code>
+            <code>&#45;&#45;overrideRoute &lt;path&gt;</code>
           </td>
           <td>
             Route to override in proxy (default: <code>/init</code>).
@@ -195,7 +195,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>--pageKeyFrom &lt;mode&gt;</code>
+            <code>&#45;&#45;pageKeyFrom &lt;mode&gt;</code>
           </td>
           <td>
             How to derive page keys: <code>filename</code> or{" "}
@@ -204,7 +204,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>--fix</code>
+            <code>&#45;&#45;fix</code>
           </td>
           <td>
             Apply lint fixes (e.g. duplicate IDs, keys starting with a number).
@@ -224,25 +224,25 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID (required).</td>
         </tr>
         <tr>
           <td>
-            <code>-p, --pages &lt;glob&gt;</code>
+            <code>-p, &#45;&#45;pages &lt;glob&gt;</code>
           </td>
           <td>Pages glob.</td>
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            <code>-o, &#45;&#45;out &lt;path&gt;</code>
           </td>
           <td>Output path for JSON.</td>
         </tr>
         <tr>
           <td>
-            <code>--pageKeyFrom &lt;mode&gt;</code>
+            <code>&#45;&#45;pageKeyFrom &lt;mode&gt;</code>
           </td>
           <td>
             <code>filename</code> or <code>export</code> (default:{" "}
@@ -251,7 +251,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>--fix</code>
+            <code>&#45;&#45;fix</code>
           </td>
           <td>Apply lint fixes.</td>
         </tr>
@@ -269,25 +269,25 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID (prompt if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>-l, --label &lt;label&gt;</code>
+            <code>-l, &#45;&#45;label &lt;label&gt;</code>
           </td>
           <td>Human-readable version label.</td>
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            <code>-b, &#45;&#45;branch &lt;branch_id&gt;</code>
           </td>
           <td>Branch ID to save to.</td>
         </tr>
         <tr>
           <td>
-            <code>-s, --skip-build</code>
+            <code>-s, &#45;&#45;skip-build</code>
           </td>
           <td>
             Use existing <code>.generated/embeddable.json</code> (no build
@@ -296,7 +296,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>--from-version &lt;number&gt;</code>
+            <code>&#45;&#45;from-version &lt;number&gt;</code>
           </td>
           <td>Base version (auto-detected from local config if not set).</td>
         </tr>
@@ -314,7 +314,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>
             Embeddable ID (prompt from local Embeddables if not provided).
@@ -334,22 +334,22 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID.</td>
         </tr>
         <tr>
           <td>
-            <code>--experiment-id &lt;id&gt;</code>
+            <code>&#45;&#45;experiment-id &lt;id&gt;</code>
           </td>
           <td>Experiment ID (prompt to choose if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>--experiment-key &lt;key&gt;</code>
+            <code>&#45;&#45;experiment-key &lt;key&gt;</code>
           </td>
           <td>
-            Experiment key (required if <code>--experiment-id</code> is set).
+            Experiment key (required if <code>&#45;&#45;experiment-id</code> is set).
           </td>
         </tr>
       </tbody>
@@ -366,7 +366,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>
             Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside <code>embeddables/&lt;id&gt;/</code>).
@@ -386,13 +386,13 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            <code>-i, &#45;&#45;id &lt;id&gt;</code>
           </td>
           <td>Embeddable ID to inspect (required).</td>
         </tr>
         <tr>
           <td>
-            <code>--version &lt;version&gt;</code>
+            <code>&#45;&#45;version &lt;version&gt;</code>
           </td>
           <td>
             Version to inspect — a version number or <code>"latest"</code> (default: <code>latest</code>).
@@ -400,13 +400,13 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            <code>-b, &#45;&#45;branch &lt;branch_id&gt;</code>
           </td>
           <td>Embeddable branch ID.</td>
         </tr>
         <tr>
           <td>
-            <code>-f, --fix</code>
+            <code>-f, &#45;&#45;fix</code>
           </td>
           <td>
             Fix by removing components missing required props (default: on).
@@ -414,7 +414,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-p, --preserve</code>
+            <code>-p, &#45;&#45;preserve</code>
           </td>
           <td>
             Preserve component order during forward compilation (default: off). Use when you want to keep existing component order for comparison purposes.
@@ -422,7 +422,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-e, --engine &lt;url&gt;</code>
+            <code>-e, &#45;&#45;engine &lt;url&gt;</code>
           </td>
           <td>
             Engine origin (default: <code>https://engine.embeddables.com</code>).

--- a/cli/faqs.mdx
+++ b/cli/faqs.mdx
@@ -22,7 +22,7 @@ description: "Frequently asked questions about the Embeddables CLI"
     Yes. Run `embeddables pull` for each; they live in `embeddables/<embeddable-id>/`. When you run `embeddables dev`, `embeddables save`, or `embeddables branch` without `-i`, you'll be prompted to choose which Embeddable to use. To avoid the prompt, **go into that Embeddable's folder** (e.g. <code>cd embeddables/&lt;EMBEDDABLE_ID&gt;</code>) and run the command from there—the CLI will automatically use that Embeddable.
   </Accordion>
   <Accordion title="First pull changes the JSON too much. How can I reduce noise?">
-    Use <strong><code>embeddables pull --preserve</code></strong>. It keeps the same order of components in the config. Most of the "changes" you see on a first pull are from React reordering components within containers—that doesn't affect how the Embeddable renders. With <code>--preserve</code>, you may still see smaller changes (e.g. <code>parent_key</code> fixes), but it's easier to verify what actually changed.
+    Use <strong><code>embeddables pull &#45;&#45;preserve</code></strong>. It keeps the same order of components in the config. Most of the "changes" you see on a first pull are from React reordering components within containers—that doesn't affect how the Embeddable renders. With <code>&#45;&#45;preserve</code>, you may still see smaller changes (e.g. <code>parent_key</code> fixes), but it's easier to verify what actually changed.
   </Accordion>
   <Accordion title="How do I point the dev server at a local Engine?">
     Use `embeddables dev --local` to use `http://localhost:8787`. Or use `embeddables dev --engine https://your-engine.example.com` for a custom URL.


### PR DESCRIPTION
Replace `--` with `&#45;&#45;` in `<code>` tags to prevent smart punctuation from converting CLI flags to en-dashes.

Mintlify's MDX processor was converting double hyphens (`--`) within `<code>` tags inside tables to en-dashes (`–`), causing CLI flags like `--version` to render incorrectly as `–version`. Using HTML entities `&#45;&#45;` ensures the hyphens are rendered correctly after the smart punctuation pass.

---
<p><a href="https://cursor.com/agents/bc-1164e4ec-a05e-4e1f-8996-759c062649fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1164e4ec-a05e-4e1f-8996-759c062649fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

