### PR TITLE
CLI docs update v0.12.1

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.12.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.12.1** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,20 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.12.1 — 5 March 2026">
+
+### Improvements
+
+- **Workbench: in-app modal dialogs in User Data panel** — The User Data panel in the Workbench now uses proper in-app modal dialogs instead of native browser `window.prompt()` calls. Both the "Save Persona" and "Go To Page" actions open a focused modal with a text input, inline error display, and keyboard shortcuts (Enter to confirm, Escape to dismiss). This also fixes the Workbench on Cursor Cloud, where native browser dialogs are not supported.
+
+### Chores
+
+- **AI development guidelines added to internal dev context** — `AI-README.md` now includes an "AI Development Guidelines" section covering code comment conventions, testing requirements, and an end-of-workflow inconsistency check. `CLAUDE.md` and `AGENTS.md` tables-of-contents were updated to reference the new section.
+- **Cursor Cloud instructions in developer docs** — `AI-README.md` and `AGENTS.md` now include specific setup and usage instructions for working within Cursor Cloud, including notes on CLI-only commands and test video recording guidelines.
+- **Developer guide centralized in `AI-README.md`** — `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/embeddables-dev.md` now point to `AI-README.md` as the single source of truth for the internal development guide.
+
+</Update>
+
 <Update label="v0.12.0 — 4 March 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.12.1