### PR TITLE
CLI docs update v0.13.0

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -32,6 +32,17 @@ description: "Complete reference for all Embeddables CLI commands and their opti
   You can `cd embeddables/<EMBEDDABLE_ID>` and run Embeddable-specific commands (`dev`, `pull`, `save`, `branch`, `builder open`) from there. The CLI will automatically use that Embeddable instead of prompting you to choose.
 </Tip>
 
+### Tasks
+
+| Command                              | Description                                       |
+| ------------------------------------ | ------------------------------------------------- |
+| `embeddables tasks list`             | List all tasks for the current project.           |
+| `embeddables tasks get`              | Fetch full details for a task by ID.              |
+| `embeddables tasks update-status`    | Change a task's status.                           |
+| `embeddables tasks assign`           | Change a task's assignee.                         |
+| `embeddables tasks comment`          | Add a comment to a task.                          |
+| `embeddables tasks add-branch`       | Link an Embeddables branch to a task.             |
+
 ### Assets
 
 | Command                      | Description                                                              |
@@ -56,6 +67,26 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 ## Command Options
 
 <AccordionGroup>
+  <Accordion title="embeddables login">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-t, --token &lt;token&gt;</code>
+          </td>
+          <td>
+            Use a token for non-interactive login. Pass a JWT directly instead of going through the OTP email flow — ideal for CI pipelines and cloud containers. The token's expiry is parsed from the JWT payload and stored alongside the session.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
   <Accordion title="embeddables init">
     <table>
       <thead>
@@ -133,6 +164,14 @@ description: "Complete reference for all Embeddables CLI commands and their opti
             <code>-p, --preserve</code>
           </td>
           <td>Preserve component order in config (see note below).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--bypass-auth</code>
+          </td>
+          <td>
+            Skip the login check. Intended for CI environments and automated tooling where no auth token is stored.
+          </td>
         </tr>
       </tbody>
     </table>
@@ -219,6 +258,14 @@ description: "Complete reference for all Embeddables CLI commands and their opti
             Apply lint fixes (e.g. duplicate IDs, keys starting with a number).
           </td>
         </tr>
+        <tr>
+          <td>
+            <code>--bypass-auth</code>
+          </td>
+          <td>
+            Skip the login check. Intended for CI environments and automated tooling where no auth token is stored.
+          </td>
+        </tr>
       </tbody>
     </table>
   </Accordion>
@@ -263,6 +310,14 @@ description: "Complete reference for all Embeddables CLI commands and their opti
             <code>--fix</code>
           </td>
           <td>Apply lint fixes.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--bypass-auth</code>
+          </td>
+          <td>
+            Skip the login check. Intended for CI environments and automated tooling where no auth token is stored.
+          </td>
         </tr>
       </tbody>
     </table>
@@ -638,6 +693,148 @@ description: "Complete reference for all Embeddables CLI commands and their opti
           <td>
             Feedback area: <code>cli</code>, <code>ai</code>, <code>compiler</code>, or <code>other</code>.
           </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks list">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-p, --project-id &lt;id&gt;</code>
+          </td>
+          <td>
+            Project ID to list tasks for. Defaults to the project configured in <code>embeddables.json</code>; prompts interactively if not set.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks get">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required). Displays status, priority, type, assignee, dates, body, and effort.</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks update-status">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-s, --status &lt;status&gt;</code>
+          </td>
+          <td>
+            New status (required). Valid values: <code>to_do</code>, <code>scoping</code>, <code>in_progress</code>, <code>feedback_cycle</code>, <code>qa</code>, <code>blocked</code>, <code>completed</code>, <code>cancelled</code>. Hyphens are accepted in place of underscores.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks assign">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--assignee-id &lt;id&gt;</code>
+          </td>
+          <td>User ID to assign the task to. Mutually exclusive with <code>--assign-to-owner</code>.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--assign-to-owner</code>
+          </td>
+          <td>Assign the task to its current owner. Mutually exclusive with <code>--assignee-id</code>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks comment">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-m, --message &lt;content&gt;</code>
+          </td>
+          <td>Comment content (required).</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks add-branch">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-b, --branch-id &lt;id&gt;</code>
+          </td>
+          <td>Branch ID to link to the task (required).</td>
         </tr>
       </tbody>
     </table>

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.12.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.13.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -130,6 +130,12 @@ The CLI provides commands for setup, daily workflow, building, and debugging. He
 | `embeddables branch` | Switch to a different branch, then pull that branch. |
 | `embeddables assets upload` | Upload a local asset folder to the Embeddables asset store. |
 | `embeddables assets sync` | Sync uploaded asset metadata into a local `assets.json` file. |
+| `embeddables tasks list` | List all tasks for the current project. |
+| `embeddables tasks get` | Fetch full details for a task by ID. |
+| `embeddables tasks update-status` | Change a task's status. |
+| `embeddables tasks assign` | Change a task's assignee. |
+| `embeddables tasks comment` | Add a comment to a task. |
+| `embeddables tasks add-branch` | Link an Embeddables branch to a task. |
 | `embeddables build` | Compile TSX to JSON without uploading. |
 | `embeddables inspect` | Round-trip compile and compare outputs for debugging. |
 | `embeddables feedback` | Send feedback about the CLI from your terminal. |

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,22 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.13.0 — 9 March 2026">
+
+### Features
+
+- **`embeddables tasks` command group** — New commands for managing project tasks directly from the CLI. All subcommands require login and resolve the project from `embeddables.json` or prompt interactively.
+  - **`tasks list`** — Display a table of all tasks for the current project (`-p, --project-id <id>` to target a specific project).
+  - **`tasks get`** — Fetch and display full details for a single task (`-i, --id <id>`): status, priority, type, assignee, dates, body, and effort.
+  - **`tasks update-status`** — Change a task's status (`-i, --id <id>`, `-s, --status <status>`). Valid values: `to_do`, `scoping`, `in_progress`, `feedback_cycle`, `qa`, `blocked`, `completed`, `cancelled`.
+  - **`tasks assign`** — Change a task's assignee (`-i, --id <id>`, then either `--assignee-id <userId>` or `--assign-to-owner` to assign to the task's owner).
+  - **`tasks comment`** — Add a comment to a task (`-i, --id <id>`, `-m, --message <content>`).
+  - **`tasks add-branch`** — Link an Embeddables branch to a task (`-i, --id <id>`, `-b, --branch-id <id>`).
+- **`embeddables login --token <token>`** — New `-t, --token` option for non-interactive, token-based login. Pass a JWT directly instead of going through the OTP email flow — ideal for CI pipelines and cloud containers where interactive prompts are unavailable.
+- **`--bypass-auth` flag for `pull`, `dev`, and `build`** — Hidden flag that skips the login check, allowing these commands to run without a stored auth token. Intended for CI environments and automated tooling. (`save` continues to require login.)
+
+</Update>
+
 <Update label="v0.12.0 — 4 March 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **New Features**
  * Introduced `embeddables tasks` command group with subcommands: `list`, `get`, `update-status`, `assign`, `comment`, and `add-branch`.
  * Added token-based login option (`embeddables login --token`) for non-interactive authentication.
  * Added `--bypass-auth` flag to enable CI/automation workflows without stored credentials.

* **Version**
  * Updated CLI version to 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->