### PR TITLE
CLI docs update v0.14.1

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -39,6 +39,23 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 | `embeddables assets upload`  | Upload a local asset folder to the Embeddables asset store.              |
 | `embeddables assets sync`    | Sync uploaded asset metadata from the cloud into a local `assets.json`. |
 
+### Tasks
+
+| Command                              | Description                                               |
+| ------------------------------------ | --------------------------------------------------------- |
+| `embeddables tasks list`             | List all tasks for the current project.                   |
+| `embeddables tasks get`              | Get details of a specific task by ID.                     |
+| `embeddables tasks update-status`    | Update a task's status.                                   |
+| `embeddables tasks assign`           | Change the assignee of a task.                            |
+| `embeddables tasks comment`          | Add a comment to a task.                                  |
+| `embeddables tasks add-branch`       | Link an Embeddable branch to a task.                      |
+
+### Branches
+
+| Command                        | Description                                                           |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `embeddables branches create`  | Create a new Embeddable branch from the current local state.          |
+
 ### Build (advanced)
 
 | Command             | Description                                                                                       |
@@ -638,6 +655,170 @@ description: "Complete reference for all Embeddables CLI commands and their opti
           <td>
             Feedback area: <code>cli</code>, <code>ai</code>, <code>compiler</code>, or <code>other</code>.
           </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks list">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-p, --project-id &lt;id&gt;</code>
+          </td>
+          <td>Project ID (defaults to <code>embeddables.json</code> or interactive prompt).</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks get">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks update-status">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-s, --status &lt;status&gt;</code>
+          </td>
+          <td>
+            New status (required). One of: <code>to_do</code>, <code>scoping</code>, <code>in_progress</code>, <code>feedback_cycle</code>, <code>qa</code>, <code>blocked</code>, <code>completed</code>, <code>cancelled</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks assign">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--assignee-id &lt;id&gt;</code>
+          </td>
+          <td>User ID to assign the task to.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--assign-to-owner</code>
+          </td>
+          <td>Assign the task back to its owner.</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks comment">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-m, --message &lt;content&gt;</code>
+          </td>
+          <td>Comment content (required).</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables tasks add-branch">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Task ID (required).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-b, --branch-id &lt;id&gt;</code>
+          </td>
+          <td>Branch ID to link to the task (required).</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables branches create">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside <code>embeddables/&lt;id&gt;/</code>).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-n, --name &lt;name&gt;</code>
+          </td>
+          <td>Branch name (required). The origin version and branch are read automatically from <code>config.json</code>.</td>
         </tr>
       </tbody>
     </table>

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.12.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.14.1** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -130,6 +130,13 @@ The CLI provides commands for setup, daily workflow, building, and debugging. He
 | `embeddables branch` | Switch to a different branch, then pull that branch. |
 | `embeddables assets upload` | Upload a local asset folder to the Embeddables asset store. |
 | `embeddables assets sync` | Sync uploaded asset metadata into a local `assets.json` file. |
+| `embeddables tasks list` | List all tasks for the current project. |
+| `embeddables tasks get` | Get details of a specific task by ID. |
+| `embeddables tasks update-status` | Update a task's status. |
+| `embeddables tasks assign` | Change the assignee of a task. |
+| `embeddables tasks comment` | Add a comment to a task. |
+| `embeddables tasks add-branch` | Link an Embeddable branch to a task. |
+| `embeddables branches create` | Create a new Embeddable branch from the current local state. |
 | `embeddables build` | Compile TSX to JSON without uploading. |
 | `embeddables inspect` | Round-trip compile and compare outputs for debugging. |
 | `embeddables feedback` | Send feedback about the CLI from your terminal. |

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,25 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.14.1 — 9 March 2026">
+
+### Features
+
+- **`embeddables tasks`** — New command group for managing project tasks directly from the terminal. All subcommands require login and resolve the project from `embeddables.json` or an interactive prompt:
+  - **`tasks list`** — Print a compact table of all tasks for the current project (`-p, --project-id <id>` to skip the prompt).
+  - **`tasks get -i <id>`** — Show full details of a single task by ID.
+  - **`tasks update-status -i <id> -s <status>`** — Change a task's status. Valid values: `to_do`, `scoping`, `in_progress`, `feedback_cycle`, `qa`, `blocked`, `completed`, `cancelled`.
+  - **`tasks assign -i <id>`** — Reassign a task. Pass `--assignee-id <user-id>` to assign to a specific user or `--assign-to-owner` to assign back to the task owner.
+  - **`tasks comment -i <id> -m <message>`** — Add a comment to a task.
+  - **`tasks add-branch -i <id> -b <branch-id>`** — Link an Embeddable branch to a task.
+- **`embeddables branches create`** — New subcommand that creates a new Embeddable branch from the current local state. Pass `-n, --name <name>` for the branch name; the origin version and branch are read automatically from `config.json`. Requires login.
+
+### Chores
+
+- **Expanded CLI help and README** — `embeddables --help` output and the package README now include full option documentation for `inspect`, `diff`, `feedback`, `builder open`, `experiments connect`, `assets upload`, `assets sync`, and all task management commands.
+
+</Update>
+
 <Update label="v0.12.0 — 4 March 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.14.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `embeddables tasks` command group with subcommands for listing, fetching details, updating status, assigning, commenting, and linking branches
  * Added `embeddables branches create` command to create branches from local state

* **Documentation**
  * Updated CLI documentation and reference guide for v0.14.1 release
  * Added comprehensive command reference for task management and branch creation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->