### PR TITLE
CLI docs update v0.14.2

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -24,7 +24,8 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 | `embeddables dev`            | Start dev server with hot reload; proxies to the Engine.                |
 | `embeddables save`           | Build and upload the Embeddable to the cloud.                           |
 | `embeddables diff`           | Compare two versions of an Embeddable (default: latest vs local).       |
-| `embeddables branch`         | Switch to a different branch (interactive list), then pull that branch. |
+| `embeddables branch`         | Switch to a different branch (interactive list or `--branch`), then pull that branch. |
+| `embeddables branches create` | Create a new branch from the current Embeddable state.                 |
 | `embeddables builder open`   | Open the Embeddables Builder in your default browser for an Embeddable. |
 | `embeddables feedback`       | Send feedback about the CLI directly from your terminal.                |
 
@@ -327,6 +328,42 @@ description: "Complete reference for all Embeddables CLI commands and their opti
           </td>
           <td>
             Embeddable ID (prompt from local Embeddables if not provided).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-b, --branch &lt;branch_id&gt;</code>
+          </td>
+          <td>
+            Branch ID or name to switch to (prompt from interactive list if not provided).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables branches create">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>
+            Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside <code>embeddables/&lt;id&gt;/</code>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-n, --name &lt;name&gt;</code>
+          </td>
+          <td>
+            Branch name (required).
           </td>
         </tr>
       </tbody>

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.12.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.14.2** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -127,7 +127,8 @@ The CLI provides commands for setup, daily workflow, building, and debugging. He
 | `embeddables dev` | Start the dev server with hot reload. |
 | `embeddables save` | Build and upload the Embeddable to the cloud. |
 | `embeddables diff` | Compare two versions of an Embeddable (default: latest vs local). |
-| `embeddables branch` | Switch to a different branch, then pull that branch. |
+| `embeddables branch` | Switch to a different branch (interactive list or `--branch`), then pull that branch. |
+| `embeddables branches create` | Create a new branch from the current Embeddable state. |
 | `embeddables assets upload` | Upload a local asset folder to the Embeddables asset store. |
 | `embeddables assets sync` | Sync uploaded asset metadata into a local `assets.json` file. |
 | `embeddables build` | Compile TSX to JSON without uploading. |

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,19 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.14.2 — 9 March 2026">
+
+### Features
+
+- **`embeddables branches create`** — New command that creates a new branch from the current Embeddable state. Resolves the Embeddable from `--id`, the current working directory, or an interactive prompt; reads the origin version and branch from `config.json`. Use `-n, --name <name>` to set the branch name (required). Requires login.
+- **`embeddables branch --branch` option** — `embeddables branch` now accepts `-b, --branch <branch_id>` to switch directly to a known branch ID or name without going through the interactive selection list.
+
+### Chores
+
+- **`branches` recognised as a utility command** — The `branches` subcommand group is now listed in the utility commands set, so branch management commands are correctly grouped in `embeddables --help` output.
+
+</Update>
+
 <Update label="v0.12.0 — 4 March 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.14.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `embeddables branches create` command to create a new branch from the current Embeddable state with required `-n, --name` flag.
  * `embeddables branch` command now supports `-b, --branch` option for non-interactive branch switching.

* **Documentation**
  * CLI version updated to 0.14.2.
  * Added v0.14.2 changelog entry documenting feature additions and command updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->