### PR TITLE
CLI docs update v0.14.3

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -25,6 +25,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 | `embeddables save`           | Build and upload the Embeddable to the cloud.                           |
 | `embeddables diff`           | Compare two versions of an Embeddable (default: latest vs local).       |
 | `embeddables branch`         | Switch to a different branch (interactive list), then pull that branch. |
+| `embeddables branches create` | Create a new branch from the current embeddable state.                 |
 | `embeddables builder open`   | Open the Embeddables Builder in your default browser for an Embeddable. |
 | `embeddables feedback`       | Send feedback about the CLI directly from your terminal.                |
 
@@ -328,6 +329,32 @@ description: "Complete reference for all Embeddables CLI commands and their opti
           <td>
             Embeddable ID (prompt from local Embeddables if not provided).
           </td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables branches create">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>
+            Embeddable ID (inferred from cwd or interactive prompt if not provided).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code>-n, --name &lt;name&gt;</code>
+          </td>
+          <td>Branch name (required). The success output will include the new branch ID returned by the server.</td>
         </tr>
       </tbody>
     </table>

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.12.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.14.3** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).
@@ -128,6 +128,7 @@ The CLI provides commands for setup, daily workflow, building, and debugging. He
 | `embeddables save` | Build and upload the Embeddable to the cloud. |
 | `embeddables diff` | Compare two versions of an Embeddable (default: latest vs local). |
 | `embeddables branch` | Switch to a different branch, then pull that branch. |
+| `embeddables branches create` | Create a new branch from the current embeddable state. |
 | `embeddables assets upload` | Upload a local asset folder to the Embeddables asset store. |
 | `embeddables assets sync` | Sync uploaded asset metadata into a local `assets.json` file. |
 | `embeddables build` | Compile TSX to JSON without uploading. |

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,18 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.14.3 — 9 March 2026">
+
+### Improvements
+
+- **`branches create` success message shows branch ID** — After successfully creating a branch, the CLI now displays both the branch name and the branch ID (as returned by the server) in the success box, making it easier to reference the new branch in subsequent commands such as `embeddables pull -b <id>` or `embeddables save -b <id>`.
+
+### Chores
+
+- **CLI option formatting** — Internal option definitions in the CLI entry point have been reformatted for consistency and readability; no user-facing changes.
+
+</Update>
+
 <Update label="v0.12.0 — 4 March 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.14.3