### PR TITLE
feat: add npm instructions

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -32,11 +32,79 @@ The Embeddables CLI lets you build, edit, and manage Embeddables using **code** 
 
 - **Node.js** >= 18.0.0
 
-## Installation
+<AccordionGroup>
+  <Accordion title="Installing Node.js and NPM on macOS">
+    The Embeddables CLI requires Node.js (which includes NPM). If you don't have Node.js installed:
 
-<Tip>
-  **Don't have Node.js or NPM installed?** See the [Installation guide](/cli/troubleshooting#installation) for setup instructions for macOS and Windows.
-</Tip>
+    **Option 1: Using Homebrew (Recommended)**
+
+    If you have Homebrew installed:
+
+    ```bash
+    brew install node
+    ```
+
+    **Option 2: Download from Node.js website**
+
+    1. Visit [nodejs.org](https://nodejs.org/)
+    2. Download the LTS (Long Term Support) version for macOS
+    3. Run the installer and follow the prompts
+
+    **Troubleshooting on macOS:**
+
+    If you see errors about missing command line tools or Xcode, you may need to install Xcode Command Line Tools first:
+
+    ```bash
+    xcode-select --install
+    ```
+
+    Click "Install" in the dialog that appears, then try installing Node.js again.
+
+    **Verifying installation:**
+
+    After installation, open a new terminal window and verify:
+
+    ```bash
+    node --version
+    npm --version
+    ```
+
+    Both commands should print version numbers.
+  </Accordion>
+
+  <Accordion title="Installing Node.js and NPM on Windows">
+    The Embeddables CLI requires Node.js (which includes NPM). If you don't have Node.js installed:
+
+    **Option 1: Using Node.js installer (Recommended)**
+
+    1. Visit [nodejs.org](https://nodejs.org/)
+    2. Download the LTS (Long Term Support) version for Windows
+    3. Run the `.msi` installer
+    4. Follow the installation wizard (keep all default options)
+    5. Restart your terminal or Command Prompt
+
+    **Option 2: Using Chocolatey**
+
+    If you have Chocolatey installed:
+
+    ```bash
+    choco install nodejs
+    ```
+
+    **Verifying installation:**
+
+    After installation, open a new terminal window and verify:
+
+    ```bash
+    node --version
+    npm --version
+    ```
+
+    Both commands should print version numbers. If you see "command not found" errors, restart your terminal or computer.
+  </Accordion>
+</AccordionGroup>
+
+## Installation
 
 Install the CLI globally:
 

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -34,6 +34,10 @@ The Embeddables CLI lets you build, edit, and manage Embeddables using **code** 
 
 ## Installation
 
+<Tip>
+  **Don't have Node.js or NPM installed?** See the [Installation guide](/cli/troubleshooting#installation) for setup instructions for macOS and Windows.
+</Tip>
+
 Install the CLI globally:
 
 ```bash

--- a/cli/troubleshooting.mdx
+++ b/cli/troubleshooting.mdx
@@ -5,6 +5,82 @@ icon: "wrench"
 description: "Fix common CLI errors and learn about current limitations"
 ---
 
+## Installation
+
+<AccordionGroup>
+  <Accordion title="Installing Node.js and NPM on macOS">
+    The Embeddables CLI requires Node.js (which includes NPM). If you don't have Node.js installed:
+
+    **Option 1: Using Homebrew (Recommended)**
+
+    If you have Homebrew installed:
+
+    ```bash
+    brew install node
+    ```
+
+    **Option 2: Download from Node.js website**
+
+    1. Visit [nodejs.org](https://nodejs.org/)
+    2. Download the LTS (Long Term Support) version for macOS
+    3. Run the installer and follow the prompts
+
+    **Troubleshooting on macOS:**
+
+    If you see errors about missing command line tools or Xcode, you may need to install Xcode Command Line Tools first:
+
+    ```bash
+    xcode-select --install
+    ```
+
+    Click "Install" in the dialog that appears, then try installing Node.js again.
+
+    **Verifying installation:**
+
+    After installation, open a new terminal window and verify:
+
+    ```bash
+    node --version
+    npm --version
+    ```
+
+    Both commands should print version numbers.
+  </Accordion>
+
+  <Accordion title="Installing Node.js and NPM on Windows">
+    The Embeddables CLI requires Node.js (which includes NPM). If you don't have Node.js installed:
+
+    **Option 1: Using Node.js installer (Recommended)**
+
+    1. Visit [nodejs.org](https://nodejs.org/)
+    2. Download the LTS (Long Term Support) version for Windows
+    3. Run the `.msi` installer
+    4. Follow the installation wizard (keep all default options)
+    5. Restart your terminal or Command Prompt
+
+    **Option 2: Using Chocolatey**
+
+    If you have Chocolatey installed:
+
+    ```bash
+    choco install nodejs
+    ```
+
+    **Verifying installation:**
+
+    After installation, open a new terminal window and verify:
+
+    ```bash
+    node --version
+    npm --version
+    ```
+
+    Both commands should print version numbers. If you see "command not found" errors, restart your terminal or computer.
+  </Accordion>
+</AccordionGroup>
+
+---
+
 ## Current limitations
 
 - **You can't create Embeddables** from the CLI; you can only pull and edit existing Embeddables (create new ones in the Builder).

--- a/cli/troubleshooting.mdx
+++ b/cli/troubleshooting.mdx
@@ -5,82 +5,6 @@ icon: "wrench"
 description: "Fix common CLI errors and learn about current limitations"
 ---
 
-## Installation
-
-<AccordionGroup>
-  <Accordion title="Installing Node.js and NPM on macOS">
-    The Embeddables CLI requires Node.js (which includes NPM). If you don't have Node.js installed:
-
-    **Option 1: Using Homebrew (Recommended)**
-
-    If you have Homebrew installed:
-
-    ```bash
-    brew install node
-    ```
-
-    **Option 2: Download from Node.js website**
-
-    1. Visit [nodejs.org](https://nodejs.org/)
-    2. Download the LTS (Long Term Support) version for macOS
-    3. Run the installer and follow the prompts
-
-    **Troubleshooting on macOS:**
-
-    If you see errors about missing command line tools or Xcode, you may need to install Xcode Command Line Tools first:
-
-    ```bash
-    xcode-select --install
-    ```
-
-    Click "Install" in the dialog that appears, then try installing Node.js again.
-
-    **Verifying installation:**
-
-    After installation, open a new terminal window and verify:
-
-    ```bash
-    node --version
-    npm --version
-    ```
-
-    Both commands should print version numbers.
-  </Accordion>
-
-  <Accordion title="Installing Node.js and NPM on Windows">
-    The Embeddables CLI requires Node.js (which includes NPM). If you don't have Node.js installed:
-
-    **Option 1: Using Node.js installer (Recommended)**
-
-    1. Visit [nodejs.org](https://nodejs.org/)
-    2. Download the LTS (Long Term Support) version for Windows
-    3. Run the `.msi` installer
-    4. Follow the installation wizard (keep all default options)
-    5. Restart your terminal or Command Prompt
-
-    **Option 2: Using Chocolatey**
-
-    If you have Chocolatey installed:
-
-    ```bash
-    choco install nodejs
-    ```
-
-    **Verifying installation:**
-
-    After installation, open a new terminal window and verify:
-
-    ```bash
-    node --version
-    npm --version
-    ```
-
-    Both commands should print version numbers. If you see "command not found" errors, restart your terminal or computer.
-  </Accordion>
-</AccordionGroup>
-
----
-
 ## Current limitations
 
 - **You can't create Embeddables** from the CLI; you can only pull and edit existing Embeddables (create new ones in the Builder).
@@ -95,7 +19,34 @@ description: "Fix common CLI errors and learn about current limitations"
 ## Common issues
 
 <AccordionGroup>
-  <Accordion title="“No Embeddables found” or “No Embeddable selected” when running dev or save">
+  <Accordion title="I don't have Node.js or NPM installed">
+    The Embeddables CLI requires Node.js version 18.0.0 or higher (which includes NPM). See the [Installation instructions in the Overview](/cli/overview#requirements) for step-by-step setup guides for macOS and Windows.
+  </Accordion>
+  <Accordion title="'npm' is not recognized as an internal or external command (Windows)">
+    This error means Node.js and NPM are not installed, or not in your system PATH. See the [Installation instructions in the Overview](/cli/overview#requirements) for how to install Node.js and NPM on Windows. After installing, restart your terminal or Command Prompt.
+  </Accordion>
+  <Accordion title="npm: command not found (macOS/Linux)">
+    This error means Node.js and NPM are not installed, or not in your PATH. See the [Installation instructions in the Overview](/cli/overview#requirements) for how to install Node.js and NPM on macOS. After installing, open a new terminal window and try again.
+  </Accordion>
+  <Accordion title="'embeddables' is not recognized or embeddables: command not found after installation">
+    After running `npm install -g @embeddables/cli`, if you get "command not found" when running `embeddables`:
+
+    1. Close and reopen your terminal (or Command Prompt on Windows)
+    2. Verify the global npm bin directory is in your PATH:
+       ```bash
+       npm config get prefix
+       ```
+       The bin folder inside that directory should be in your PATH.
+    3. On macOS/Linux, you may need to add npm's global bin to your PATH in `~/.zshrc` or `~/.bashrc`:
+       ```bash
+       export PATH="$(npm config get prefix)/bin:$PATH"
+       ```
+       Then restart your terminal or run `source ~/.zshrc` (or `~/.bashrc`).
+    4. On Windows, the npm global folder should be added automatically, but you may need to restart your computer.
+
+    If Node.js and NPM aren't installed yet, see the [Installation instructions in the Overview](/cli/overview#requirements).
+  </Accordion>
+  <Accordion title="'No Embeddables found' or 'No Embeddable selected' when running dev or save">
     Run from the **project root** (where `embeddables.json` and the `embeddables/` folder are), or from inside `embeddables/<id>/` so the CLI infers the Embeddable, or pass `-i <embeddable-id>`. If you haven't pulled yet, run `embeddables pull` first so that `embeddables/<id>/` exists.
   </Accordion>
   <Accordion title="Port 3000 is already in use">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Node.js and NPM installation prerequisites and verification steps for macOS and Windows in the CLI docs.
  * Expanded CLI troubleshooting with four Node/NPM-focused entries covering missing tools, OS-specific recognition errors, PATH checks, and restart guidance.
  * Reordered troubleshooting so Node/NPM issues appear before the existing "No Embeddables found" guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->