### PR TITLE
fix: remove em dashes

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -67,7 +67,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-p, --project-id &lt;id&gt;</code>
+            `-p, --project-id <id>`
           </td>
           <td>
             Set project ID (if logged in, you can pick from a list instead).
@@ -75,7 +75,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-y, --yes</code>
+            `-y, --yes`
           </td>
           <td>Skip prompts and use defaults.</td>
         </tr>
@@ -93,36 +93,36 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID to pull (skips interactive selection).</td>
         </tr>
         <tr>
           <td>
-            <code>--version [number]</code>
+            `--version [number]`
           </td>
           <td>
-            Version to pull. Omit a value (<code>--version</code>) to open an interactive version selector. Pass a number (<code>--version 47</code>) to pull a specific version. Without this flag, <code>pull</code> defaults to the latest version.
+            Version to pull. Omit a value (`--version`) to open an interactive version selector. Pass a number (`--version 47`) to pull a specific version. Without this flag, `pull` defaults to the latest version.
           </td>
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            `-o, --out <path>`
           </td>
           <td>
             Output path for compiled JSON (default:{" "}
-            <code>embeddables/&lt;id&gt;/.generated/embeddable.json</code>).
+            `embeddables/<id>/.generated/embeddable.json`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            `-b, --branch <branch_id>`
           </td>
           <td>Pull a specific branch.</td>
         </tr>
         <tr>
           <td>
-            <code>-f, --fix</code>
+            `-f, --fix`
           </td>
           <td>
             Remove components with missing required props instead of erroring.
@@ -130,7 +130,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-p, --preserve</code>
+            `-p, --preserve`
           </td>
           <td>Preserve component order in config (see note below).</td>
         </tr>
@@ -148,72 +148,72 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID (prompt if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>-p, --pages &lt;glob&gt;</code>
+            `-p, --pages <glob>`
           </td>
           <td>
             Custom pages glob (default:{" "}
-            <code>embeddables/&lt;id&gt;/pages/**/*.page.tsx</code>).
+            `embeddables/<id>/pages/**/*.page.tsx`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            `-o, --out <path>`
           </td>
           <td>Output path for compiled JSON.</td>
         </tr>
         <tr>
           <td>
-            <code>-L, --local</code>
+            `-L, --local`
           </td>
           <td>
-            Use local engine (<code>http://localhost:8787</code>) instead of
+            Use local engine (`http://localhost:8787`) instead of
             production.
           </td>
         </tr>
         <tr>
           <td>
-            <code>-e, --engine &lt;url&gt;</code>
+            `-e, --engine <url>`
           </td>
           <td>
-            Engine origin (default: <code>https://engine.embeddables.com</code>;
-            overridden by <code>--local</code>).
+            Engine origin (default: `https://engine.embeddables.com`;
+            overridden by `--local`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>--port &lt;n&gt;</code>
+            `--port <n>`
           </td>
           <td>
-            Dev proxy port (default: <code>3000</code>). If in use, CLI tries
+            Dev proxy port (default: `3000`). If in use, CLI tries
             the next available port.
           </td>
         </tr>
         <tr>
           <td>
-            <code>--overrideRoute &lt;path&gt;</code>
+            `--overrideRoute <path>`
           </td>
           <td>
-            Route to override in proxy (default: <code>/init</code>).
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <code>--pageKeyFrom &lt;mode&gt;</code>
-          </td>
-          <td>
-            How to derive page keys: <code>filename</code> or{" "}
-            <code>export</code> (default: <code>filename</code>).
+            Route to override in proxy (default: `/init`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>--fix</code>
+            `--pageKeyFrom <mode>`
+          </td>
+          <td>
+            How to derive page keys: `filename` or{" "}
+            `export` (default: `filename`).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            `--fix`
           </td>
           <td>
             Apply lint fixes (e.g. duplicate IDs, keys starting with a number).
@@ -233,34 +233,34 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID (required).</td>
         </tr>
         <tr>
           <td>
-            <code>-p, --pages &lt;glob&gt;</code>
+            `-p, --pages <glob>`
           </td>
           <td>Pages glob.</td>
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            `-o, --out <path>`
           </td>
           <td>Output path for JSON.</td>
         </tr>
         <tr>
           <td>
-            <code>--pageKeyFrom &lt;mode&gt;</code>
+            `--pageKeyFrom <mode>`
           </td>
           <td>
-            <code>filename</code> or <code>export</code> (default:{" "}
-            <code>filename</code>).
+            `filename` or `export` (default:{" "}
+            `filename`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>--fix</code>
+            `--fix`
           </td>
           <td>Apply lint fixes.</td>
         </tr>
@@ -278,34 +278,34 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID (prompt if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>-l, --label &lt;label&gt;</code>
+            `-l, --label <label>`
           </td>
           <td>Human-readable version label.</td>
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            `-b, --branch <branch_id>`
           </td>
           <td>Branch ID to save to.</td>
         </tr>
         <tr>
           <td>
-            <code>-s, --skip-build</code>
+            `-s, --skip-build`
           </td>
           <td>
-            Use existing <code>.generated/embeddable.json</code> (no build
+            Use existing `.generated/embeddable.json` (no build
             step).
           </td>
         </tr>
         <tr>
           <td>
-            <code>--from-version &lt;number&gt;</code>
+            `--from-version <number>`
           </td>
           <td>Base version (auto-detected from local config if not set).</td>
         </tr>
@@ -323,7 +323,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>
             Embeddable ID (prompt from local Embeddables if not provided).
@@ -343,22 +343,22 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID.</td>
         </tr>
         <tr>
           <td>
-            <code>--experiment-id &lt;id&gt;</code>
+            `--experiment-id <id>`
           </td>
           <td>Experiment ID (prompt to choose if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>--experiment-key &lt;key&gt;</code>
+            `--experiment-key <key>`
           </td>
           <td>
-            Experiment key (required if <code>--experiment-id</code> is set).
+            Experiment key (required if `--experiment-id` is set).
           </td>
         </tr>
       </tbody>
@@ -375,10 +375,10 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>
-            Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside <code>embeddables/&lt;id&gt;/</code>).
+            Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside `embeddables/<id>/`).
           </td>
         </tr>
       </tbody>
@@ -395,27 +395,27 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID to inspect (required).</td>
         </tr>
         <tr>
           <td>
-            <code>--version &lt;version&gt;</code>
+            `--version <version>`
           </td>
           <td>
-            Version to inspect — a version number or <code>"latest"</code> (default: <code>latest</code>).
+            Version to inspect — a version number or `"latest"` (default: `latest`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            `-b, --branch <branch_id>`
           </td>
           <td>Embeddable branch ID.</td>
         </tr>
         <tr>
           <td>
-            <code>-f, --fix</code>
+            `-f, --fix`
           </td>
           <td>
             Fix by removing components missing required props (default: on).
@@ -423,7 +423,7 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-p, --preserve</code>
+            `-p, --preserve`
           </td>
           <td>
             Preserve component order during forward compilation (default: off). Use when you want to keep existing component order for comparison purposes.
@@ -431,10 +431,10 @@ description: "Complete reference for all Embeddables CLI commands and their opti
         </tr>
         <tr>
           <td>
-            <code>-e, --engine &lt;url&gt;</code>
+            `-e, --engine <url>`
           </td>
           <td>
-            Engine origin (default: <code>https://engine.embeddables.com</code>).
+            Engine origin (default: `https://engine.embeddables.com`).
           </td>
         </tr>
       </tbody>
@@ -451,63 +451,63 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
-          <td>Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside <code>embeddables/&lt;id&gt;/</code>).</td>
+          <td>Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside `embeddables/<id>/`).</td>
         </tr>
         <tr>
           <td>
-            <code>--from &lt;version&gt;</code>
+            `--from <version>`
           </td>
           <td>
-            Version to compare from (default: <code>latest</code>). Accepts a version number, <code>latest</code>, <code>staging</code>, <code>prod</code>, <code>local</code>, or <code>branch@version</code>.
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <code>--to &lt;version&gt;</code>
-          </td>
-          <td>
-            Version to compare to (default: <code>local</code>). Same format as <code>--from</code>.
+            Version to compare from (default: `latest`). Accepts a version number, `latest`, `staging`, `prod`, `local`, or `branch@version`.
           </td>
         </tr>
         <tr>
           <td>
-            <code>--depth &lt;level&gt;</code>
+            `--to <version>`
           </td>
           <td>
-            Detail level: <code>pages</code>, <code>components</code> (default), or <code>props</code>.
+            Version to compare to (default: `local`). Same format as `--from`.
           </td>
         </tr>
         <tr>
           <td>
-            <code>--page &lt;keysOrIds&gt;</code>
+            `--depth <level>`
+          </td>
+          <td>
+            Detail level: `pages`, `components` (default), or `props`.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            `--page <keysOrIds>`
           </td>
           <td>Filter output to specific page keys or IDs (comma-separated, no spaces).</td>
         </tr>
         <tr>
           <td>
-            <code>--component &lt;keysOrIds&gt;</code>
+            `--component <keysOrIds>`
           </td>
           <td>Filter output to specific component keys or IDs (comma-separated, no spaces).</td>
         </tr>
         <tr>
           <td>
-            <code>-b, --branch &lt;branch_id&gt;</code>
+            `-b, --branch <branch_id>`
           </td>
-          <td>Branch to use when fetching cloud versions (auto-detected from <code>config.json</code> if not set).</td>
+          <td>Branch to use when fetching cloud versions (auto-detected from `config.json` if not set).</td>
         </tr>
         <tr>
           <td>
-            <code>-e, --engine &lt;url&gt;</code>
+            `-e, --engine <url>`
           </td>
           <td>
-            Engine origin (default: <code>https://engine.embeddables.com</code>).
+            Engine origin (default: `https://engine.embeddables.com`).
           </td>
         </tr>
         <tr>
           <td>
-            <code>--no-color</code>
+            `--no-color`
           </td>
           <td>Disable colored output.</td>
         </tr>
@@ -525,51 +525,51 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID (inferred from cwd or interactive prompt if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>--dir &lt;path&gt;</code>
+            `--dir <path>`
           </td>
-          <td>Local directory to upload from (default: <code>assets/</code>).</td>
+          <td>Local directory to upload from (default: `assets/`).</td>
         </tr>
         <tr>
           <td>
-            <code>--group-id &lt;id&gt;</code>
+            `--group-id <id>`
           </td>
           <td>Target asset group ID. Resolved from project config if not provided.</td>
         </tr>
         <tr>
           <td>
-            <code>--recursive</code>
+            `--recursive`
           </td>
           <td>Traverse subdirectories (default: top-level only).</td>
         </tr>
         <tr>
           <td>
-            <code>--include &lt;glob&gt;</code>
+            `--include <glob>`
           </td>
           <td>Glob pattern to include only matching files.</td>
         </tr>
         <tr>
           <td>
-            <code>--exclude &lt;glob&gt;</code>
+            `--exclude <glob>`
           </td>
           <td>Glob pattern to exclude matching files.</td>
         </tr>
         <tr>
           <td>
-            <code>--dry-run</code>
+            `--dry-run`
           </td>
           <td>Preview what would be uploaded without actually uploading.</td>
         </tr>
         <tr>
           <td>
-            <code>--workers &lt;n&gt;</code>
+            `--workers <n>`
           </td>
-          <td>Number of concurrent upload workers (default: <code>5</code>).</td>
+          <td>Number of concurrent upload workers (default: `5`).</td>
         </tr>
       </tbody>
     </table>
@@ -585,21 +585,21 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>-i, --id &lt;id&gt;</code>
+            `-i, --id <id>`
           </td>
           <td>Embeddable ID (inferred from cwd or interactive prompt if not provided).</td>
         </tr>
         <tr>
           <td>
-            <code>--group-id &lt;id&gt;</code>
+            `--group-id <id>`
           </td>
           <td>Asset group ID to sync. Resolved from project config if not provided.</td>
         </tr>
         <tr>
           <td>
-            <code>-o, --out &lt;path&gt;</code>
+            `-o, --out <path>`
           </td>
-          <td>Output path for the asset manifest (default: <code>assets.json</code>).</td>
+          <td>Output path for the asset manifest (default: `assets.json`).</td>
         </tr>
       </tbody>
     </table>
@@ -615,28 +615,28 @@ description: "Complete reference for all Embeddables CLI commands and their opti
       <tbody>
         <tr>
           <td>
-            <code>[message]</code>
+            `[message]`
           </td>
           <td>Optional feedback message as a positional argument. If omitted, you will be prompted interactively.</td>
         </tr>
         <tr>
           <td>
-            <code>--positive</code>
+            `--positive`
           </td>
           <td>Mark the feedback as positive (👍).</td>
         </tr>
         <tr>
           <td>
-            <code>--negative</code>
+            `--negative`
           </td>
           <td>Mark the feedback as negative (👎). Default when a message is passed non-interactively.</td>
         </tr>
         <tr>
           <td>
-            <code>--category &lt;type&gt;</code>
+            `--category <type>`
           </td>
           <td>
-            Feedback area: <code>cli</code>, <code>ai</code>, <code>compiler</code>, or <code>other</code>.
+            Feedback area: `cli`, `ai`, `compiler`, or `other`.
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Replace all em dashes (—) with double hyphens (--) throughout the CLI documentation for consistency with command-line syntax         
  conventions.                                                                                                                         
                                                                                                                                       
  Changes:                                                                                                                             
  - 16 replacements across 5 files: overview.mdx, troubleshooting.mdx, commands.mdx, faqs.mdx, ai.mdx                                  
  - Affects prose text only; all flag syntax was already correct                                                                       
                                                                                                                                       
  Why: Em dashes were being used as punctuation in descriptions, which could cause confusion with CLI flag syntax that uses double     
  hyphens.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced readability of CLI command documentation through consistent code formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->