### PR TITLE
Remove Linear task references from CLI changelog

### DIFF
--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -15,22 +15,22 @@ Check your version: `embeddables -v`
 
 ### Features
 
-- **Shared `AI-README.md` + short pointer rule files** (CLI-105) — `embeddables init` now creates a shared `AI-README.md` at the project root containing the full Embeddables CLI development guide. The AI editor rule files for Cursor (`.cursor/rules/embeddables-cli.md`), Claude (`.claude/embeddables-cli.md`), Codex (`AGENTS.md`), and Antigravity (`.agent/rules/embeddables-cli.md`) are now concise pointer files that reference `AI-README.md`, rather than each duplicating the full content. This keeps rule files small and ensures they stay in sync.
+- **Shared `AI-README.md` + short pointer rule files** — `embeddables init` now creates a shared `AI-README.md` at the project root containing the full Embeddables CLI development guide. The AI editor rule files for Cursor (`.cursor/rules/embeddables-cli.md`), Claude (`.claude/embeddables-cli.md`), Codex (`AGENTS.md`), and Antigravity (`.agent/rules/embeddables-cli.md`) are now concise pointer files that reference `AI-README.md`, rather than each duplicating the full content. This keeps rule files small and ensures they stay in sync.
 - **`embeddables upgrade` refreshes AI context files and type stubs** — Running `embeddables upgrade` now also regenerates AI rule files and `.types/` type stubs in the project to match the newly installed CLI version, so they stay up to date automatically without needing to re-run `embeddables init`.
 - **`preserve_json_in_cli` for `CustomHTML`** — `CustomHTML` components now accept a `preserve_json_in_cli` boolean prop. When set, the HTML content is preserved as-is during CLI round-trips, bypassing HTML reformatting. Useful for raw embeds that should not be touched by the compiler.
 
 ### Bug Fixes
 
-- **Workbench: `OptionSelector` dropdown autofill** (CLI-88) — Dropdowns in the Workbench field editor now autofill correctly. Fixed by removing an empty-buttons guard and switching to `setUserData` for consistent state propagation.
-- **`embeddables branch`: soft-deleted branches hidden** (CLI-64) — Soft-deleted branches are now filtered out of the interactive branch selection prompt, keeping the list clean.
-- **`CustomHTML`: whitespace trimming and hyphenated SVG attributes** (CLI-73) — Whitespace in `CustomHTML` text content is now trimmed correctly; hyphenated SVG attributes (e.g. `stroke-width`, `fill-rule`, `stroke-linecap`) are preserved through round-trips.
-- **`embeddables pull`: reduced style-only diffs** (CLI-92) — Fixed an issue where pulling could introduce unwanted whitespace changes in `CustomHTML` serialization, causing spurious diffs.
-- **Edit history: array value diffs** (CLI-86) — Array-type values in edit history now diff correctly when saving, preventing spurious change records.
-- **Page-level trigger output types** (CLI-77) — Page-level outputs now correctly identify trigger output types, improving type safety.
+- **Workbench: `OptionSelector` dropdown autofill** — Dropdowns in the Workbench field editor now autofill correctly. Fixed by removing an empty-buttons guard and switching to `setUserData` for consistent state propagation.
+- **`embeddables branch`: soft-deleted branches hidden** — Soft-deleted branches are now filtered out of the interactive branch selection prompt, keeping the list clean.
+- **`CustomHTML`: whitespace trimming and hyphenated SVG attributes** — Whitespace in `CustomHTML` text content is now trimmed correctly; hyphenated SVG attributes (e.g. `stroke-width`, `fill-rule`, `stroke-linecap`) are preserved through round-trips.
+- **`embeddables pull`: reduced style-only diffs** — Fixed an issue where pulling could introduce unwanted whitespace changes in `CustomHTML` serialization, causing spurious diffs.
+- **Edit history: array value diffs** — Array-type values in edit history now diff correctly when saving, preventing spurious change records.
+- **Page-level trigger output types** — Page-level outputs now correctly identify trigger output types, improving type safety.
 
 ### Improvements
 
-- **Computed field and action function signatures** (CLI-76) — `result()` and `output()` now accept the full three-argument form (`userData`, `helperFunctions`, `triggerContext`). Trailing unused parameters can be omitted, keeping simple computed fields concise.
+- **Computed field and action function signatures** — `result()` and `output()` now accept the full three-argument form (`userData`, `helperFunctions`, `triggerContext`). Trailing unused parameters can be omitted, keeping simple computed fields concise.
 
 ### Chores
 
@@ -94,7 +94,7 @@ Check your version: `embeddables -v`
 
 ### Features
 
-- **Non-interactive flags for all commands (CLI-57)** — Every interactive prompt in the CLI (excluding `login`) now has a corresponding flag, making all commands fully scriptable for use in CI pipelines, AI-driven workflows, and automation:
+- **Non-interactive flags for all commands** — Every interactive prompt in the CLI (excluding `login`) now has a corresponding flag, making all commands fully scriptable for use in CI pipelines, AI-driven workflows, and automation:
   - **`embeddables branch`**: `--branch <id|name>` skips the branch selection prompt.
   - **`embeddables save`**: `--project-id <id>` skips the project selection prompt; `--force` skips all confirmation prompts (version conflicts and other users' drafts).
   - **`embeddables pull`**: `--project-id <id>` skips the project selection prompt.
@@ -142,7 +142,7 @@ Check your version: `embeddables -v`
 
 ### Bug Fixes
 
-- **Video mute/play state lost on `pull` (CLI-49)** — Fixed two root causes that caused `<video muted autoplay loop>` and related MediaEmbed properties to disappear after `embeddables pull`. First, several `MediaEmbed` component-specific props (`silentAutoplayPreview`, `hide_controls`, `central_play_button`, `roundedCorners`, `embed_code`, `placeholder_image_url`, `embed_code_raw`) were missing from `COMPONENT_SPECIFIC_PROPS` and are now correctly included. Second, the HTML-to-JSX parser in `CustomHTML` was silently dropping boolean HTML attributes (those without `=` signs) — `muted`, `autoplay`, `loop`, etc. now survive as proper JSX boolean attributes.
+- **Video mute/play state lost on `pull`** — Fixed two root causes that caused `<video muted autoplay loop>` and related MediaEmbed properties to disappear after `embeddables pull`. First, several `MediaEmbed` component-specific props (`silentAutoplayPreview`, `hide_controls`, `central_play_button`, `roundedCorners`, `embed_code`, `placeholder_image_url`, `embed_code_raw`) were missing from `COMPONENT_SPECIFIC_PROPS` and are now correctly included. Second, the HTML-to-JSX parser in `CustomHTML` was silently dropping boolean HTML attributes (those without `=` signs) — `muted`, `autoplay`, `loop`, etc. now survive as proper JSX boolean attributes.
 
 ### Improvements
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removed internal Linear-style task IDs (for example `(CLI-92)`) from bullets in `reference/changelog/cli-changelog.mdx` so changelog entries read cleanly without tracker references.

## Changes

- Stripped all `(CLI-NNN)` parenthetical references from affected feature, bug fix, and improvement lines.

No other changelog files contained these patterns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f5c0cfe-6f7c-4b63-9467-2b347886d388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f5c0cfe-6f7c-4b63-9467-2b347886d388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI changelog by removing explicit issue/PR identifiers from numerous changelog entries for various features, including autofill, branch handling, whitespace trimming, diffs, field signatures, command flags, and media playback fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->