### PR TITLE
CLI docs update v0.15.1-beta.0

### DIFF
--- a/cli/ai.mdx
+++ b/cli/ai.mdx
@@ -28,8 +28,8 @@ Use Cursor for quick edits to a single page, adding a component, or fixing a pro
 
 When you run `embeddables init`, the CLI can also add **Claude (Claude Code / project) context**:
 
-- **Where it goes**: `.claude/` with `CLAUDE.md` (short intro pointer) and `embeddables-cli.md` (pointer to `AI-README.md`).
-- **What it does**: Claude uses these files as project context when you work in the repo. The pointer in `.claude/embeddables-cli.md` directs Claude to `AI-README.md`, which covers pages, global components, styles, computed fields, actions, and component primitives.
+- **Where it goes**: `.claude/CLAUDE.md` (a short pointer to `AI-README.md`).
+- **What it does**: Claude uses this file as project context when you work in the repo. The pointer in `.claude/CLAUDE.md` directs Claude to `AI-README.md`, which covers pages, global components, styles, computed fields, actions, and component primitives.
 - **Referencing it in prompts**: In a Claude Code or project prompt, you can say: "Always read the Embeddables CLI context before starting (e.g. `AI-README.md`)." For complex tasks (e.g. building multiple pages from designs), the CLI repo also includes example prompts in `.prompts/custom/` (e.g. build-funnel style) that you can adapt and paste into Claude.
 - **Re-injecting**: Run `embeddables init` or `embeddables upgrade` to recreate or refresh `.claude/` with the latest content.
 

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -51,17 +51,6 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 | `embeddables assets upload`  | Upload a local asset folder to the Embeddables asset store.              |
 | `embeddables assets sync`    | Sync uploaded asset metadata from the cloud into a local `assets.json`. |
 
-### Tasks
-
-| Command                              | Description                                               |
-| ------------------------------------ | --------------------------------------------------------- |
-| `embeddables tasks list`             | List all tasks for the current project.                   |
-| `embeddables tasks get`              | Get details of a specific task by ID.                     |
-| `embeddables tasks update-status`    | Update a task's status.                                   |
-| `embeddables tasks assign`           | Change the assignee of a task.                            |
-| `embeddables tasks comment`          | Add a comment to a task.                                  |
-| `embeddables tasks add-branch`       | Link an Embeddable branch to a task.                      |
-
 ### Branches
 
 | Command                        | Description                                                           |

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -51,6 +51,23 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 | `embeddables assets upload`  | Upload a local asset folder to the Embeddables asset store.              |
 | `embeddables assets sync`    | Sync uploaded asset metadata from the cloud into a local `assets.json`. |
 
+### Tasks
+
+| Command                              | Description                                               |
+| ------------------------------------ | --------------------------------------------------------- |
+| `embeddables tasks list`             | List all tasks for the current project.                   |
+| `embeddables tasks get`              | Get details of a specific task by ID.                     |
+| `embeddables tasks update-status`    | Update a task's status.                                   |
+| `embeddables tasks assign`           | Change the assignee of a task.                            |
+| `embeddables tasks comment`          | Add a comment to a task.                                  |
+| `embeddables tasks add-branch`       | Link an Embeddable branch to a task.                      |
+
+### Branches
+
+| Command                        | Description                                                           |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `embeddables branches create`  | Create a new Embeddable branch from the current local state.          |
+
 ### Build (advanced)
 
 | Command             | Description                                                                                       |

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -51,28 +51,17 @@ description: "Complete reference for all Embeddables CLI commands and their opti
 | `embeddables assets upload`  | Upload a local asset folder to the Embeddables asset store.              |
 | `embeddables assets sync`    | Sync uploaded asset metadata from the cloud into a local `assets.json`. |
 
-### Tasks
-
-| Command                              | Description                                               |
-| ------------------------------------ | --------------------------------------------------------- |
-| `embeddables tasks list`             | List all tasks for the current project.                   |
-| `embeddables tasks get`              | Get details of a specific task by ID.                     |
-| `embeddables tasks update-status`    | Update a task's status.                                   |
-| `embeddables tasks assign`           | Change the assignee of a task.                            |
-| `embeddables tasks comment`          | Add a comment to a task.                                  |
-| `embeddables tasks add-branch`       | Link an Embeddable branch to a task.                      |
-
-### Branches
-
-| Command                        | Description                                                           |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `embeddables branches create`  | Create a new Embeddable branch from the current local state.          |
-
 ### Build (advanced)
 
 | Command             | Description                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
 | `embeddables build` | Compile TSX → JSON only (no upload). Used automatically by `save` unless you pass `--skip-build`. |
+
+### Publishing (advanced)
+
+| Command                              | Description                                                                                         |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `embeddables dangerously-publish`    | Promote an existing saved version to staging or production without a full rebuild. Use with care.   |
 
 ### Debugging
 
@@ -939,6 +928,78 @@ description: "Complete reference for all Embeddables CLI commands and their opti
             <code>-n, --name &lt;name&gt;</code>
           </td>
           <td>Branch name (required). The origin version and branch are read automatically from <code>config.json</code>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </Accordion>
+  <Accordion title="embeddables dangerously-publish">
+    <table>
+      <thead>
+        <tr>
+          <th>Option</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code>-i, --id &lt;id&gt;</code>
+          </td>
+          <td>Embeddable ID (prompt if not provided).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--staging</code>
+          </td>
+          <td>Publish to the staging environment. Mutually exclusive with <code>--prod</code>.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--prod</code>
+          </td>
+          <td>Publish to production only (the version must already be on staging server-side). Mutually exclusive with <code>--staging</code>.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--via-staging</code>
+          </td>
+          <td>With <code>--prod</code>: push to staging first, then to production. Use when the version is not yet on staging.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--save</code>
+          </td>
+          <td>Build and upload a new saved version before publishing it.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--publish-version &lt;number&gt;</code>
+          </td>
+          <td>Promote this specific version number instead of reading the version from <code>config.json</code>.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-l, --label &lt;label&gt;</code>
+          </td>
+          <td>Human-readable label for the new version (only applies with <code>--save</code>).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--skip-build</code>
+          </td>
+          <td>Skip the build step (only applies with <code>--save</code>).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>-p, --project-id &lt;id&gt;</code>
+          </td>
+          <td>Project ID (skips project selection prompt).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>--force</code>
+          </td>
+          <td>Skip confirmation prompts (version conflicts when using <code>--save</code>, other users' drafts).</td>
         </tr>
       </tbody>
     </table>

--- a/cli/faqs.mdx
+++ b/cli/faqs.mdx
@@ -13,7 +13,7 @@ description: "Frequently asked questions about the Embeddables CLI"
     Login is stored globally on your machine (not per project). Use `embeddables logout` to clear it.
   </Accordion>
   <Accordion title="Can I use the CLI without ever using the Builder?">
-    You can build and save Embeddables entirely from the CLI. The Builder is still the recommended place to create new branches/experiments, upload assets, and for non-technical teammates to review and merge. Many teams use both: CLI for fast iteration and AI-assisted edits, Builder for final review and publishing.
+    You can build and save Embeddables entirely from the CLI. The Builder is still the recommended place to create experiments, upload assets, and for non-technical teammates to review and merge. Many teams use both: CLI for fast iteration and AI-assisted edits, Builder for final review and publishing.
   </Accordion>
   <Accordion title="What is the difference between id and key on components?">
     Both must be unique in context. `id` is the stable internal identifier (e.g. `comp_12345`). `key` is used in React and for targeting (e.g. in conditions or user data). Keys must not start with a number; use a prefix like `option_` or `range_` if the label would otherwise slug to a number.
@@ -37,7 +37,7 @@ description: "Frequently asked questions about the Embeddables CLI"
     Run `embeddables upgrade`. You can check the current version with `embeddables -v`.
   </Accordion>
   <Accordion title="Can I create a new branch or experiment from the CLI?">
-    No. You can switch to and pull existing branches with `embeddables branch`, and connect an Embeddable to an experiment with `embeddables experiments connect`, but creating new branches or experiments is done in the Builder.
+    You can create new branches with `embeddables branches create` and switch between them with `embeddables branch`. Creating experiments is still done in the Builder; use `embeddables experiments connect` to link an existing experiment to your Embeddable.
   </Accordion>
   <Accordion title="Why does save say the server has a newer version?">
     Someone (in the Builder or via the CLI) saved a newer version after you last pulled. You can pull the latest with `embeddables pull` and then re-apply your changes, or force-save when the prompt offers it (use with care to avoid overwriting others' work).

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.15.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.15.1-beta.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/cli/troubleshooting.mdx
+++ b/cli/troubleshooting.mdx
@@ -9,7 +9,7 @@ description: "Fix common CLI errors and learn about current limitations"
 
 - **You can't create Embeddables** from the CLI; you can only pull and edit existing Embeddables (create new ones in the Builder).
 - **Asset browsing and deletion** are not yet available from the CLI. Use the Builder to browse the full asset library or delete assets. To upload local assets and reference their URLs in code, use `embeddables assets upload` and then `embeddables assets sync` to pull the URLs into `assets.json`.
-- **No creating new branches/experiments** from the CLI; you can connect to existing ones (`embeddables branch`, `embeddables experiments connect`).
+- **No creating new experiments** from the CLI; use the Builder to create experiments, then connect with `embeddables experiments connect`. You can create and switch branches with `embeddables branches create` and `embeddables branch`.
 - **`embeddables dev` doesn't yet work** for Embeddables that use the CMS feature; use the Builder preview or a deployed embed for those.
 - **Multi-language Embeddables** are supported in round-trip compilation; some edge cases with complex language configurations may still arise — report them if you encounter them.
 - **Internet required** for the dev server when using the default (remote) Engine.

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -28,10 +28,6 @@ Check your version: `embeddables -v`
 - **`embeddables init` / `upgrade`: single Claude rule file** — `embeddables init` and `upgrade` now write `.claude/CLAUDE.md` only; the legacy `.claude/embeddables-cli.md` file is removed on upgrade. Aligns with Claude Code conventions and avoids duplicate context.
 - **Workbench: toast notification fixes** — Toast is now positioned above the Workbench bar (outside the panel), aligned to the right, with improved contrast (solid success/error colors), correct state reset when the Embeddable ID changes, and proper timer cleanup on unmount.
 
-### Chores
-
-- **PR template: risk assessment section** — The internal PR template now includes a risk assessment field.
-
 </Update>
 
 <Update label="v0.15.0 — 23 March 2026">

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,29 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.15.1-beta.0 — 27 March 2026">
+
+### Features
+
+- **Workbench: Feedback Panel** — A new Feedback panel in the Workbench lets you submit annotated feedback on an Embeddable directly from the preview. Supports image paste (including on Windows), session upload management, tagging, and a shared session welcome modal. Feedback is stored with the project ID from `embeddables.json`, injected automatically in dev mode.
+- **`embeddables dangerously-publish`** — New command that promotes an existing saved version to staging or production without a full rebuild. Requires exactly one of `--staging` or `--prod`. Use `--via-staging` with `--prod` if the version is not yet on staging. Pass `--save` to upload a new saved version first, or `--publish-version <number>` to target a specific version instead of reading from `config.json`.
+- **`embeddables inspect`: fixable failures shown as warnings with fix-and-retry prompt** — When `inspect` encounters component-level issues that can be auto-fixed (e.g. missing required props), it now displays a warning and prompts you to retry with `--fix` rather than exiting immediately. The prompt defaults to yes, preserving the previous auto-fix feel. Matches the existing behaviour in `embeddables pull`.
+- **`OptionSelector` placeholder prop** — `OptionSelector` now accepts a first-class `placeholder` prop with full multi-language translation support.
+- **Workbench: Reset User Data toast** — The Workbench now shows a toast confirmation when user data is reset.
+
+### Bug Fixes
+
+- **Workbench: image paste on Windows** — Pasted images are now accepted when the clipboard item's MIME type is empty, which occurs in some Windows browsers and clipboard sources.
+- **`embeddables save`: 500 error response body surfaced** — When the server returns a 500 during `save`, the response body is now parsed and included in the displayed error message.
+- **`embeddables init` / `upgrade`: single Claude rule file** — `embeddables init` and `upgrade` now write `.claude/CLAUDE.md` only; the legacy `.claude/embeddables-cli.md` file is removed on upgrade. Aligns with Claude Code conventions and avoids duplicate context.
+- **Workbench: toast notification fixes** — Toast is now positioned above the Workbench bar (outside the panel), aligned to the right, with improved contrast (solid success/error colors), correct state reset when the Embeddable ID changes, and proper timer cleanup on unmount.
+
+### Chores
+
+- **PR template: risk assessment section** — The internal PR template now includes a risk assessment field.
+
+</Update>
+
 <Update label="v0.15.0 — 23 March 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.15.1-beta.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI branching/experiment workflows and FAQs; bumped CLI docs to 0.15.1-beta.0; consolidated Claude project context to a single pointer file.
* **New Features**
  * Workbench feedback panel with annotated feedback and image-paste support; added advanced `dangerously-publish` CLI options (staging/prod, via-staging, versioning, build/upload controls).
* **Bug Fixes**
  * Fixed Windows image-paste, improved save error messages, toast behavior, and inspect auto-fix flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->