### PR TITLE
Web App docs update (PR #1742)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,13 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="31 March 2026">
+### 🐞 Bug Fixes
+
+- **Decimal Experiment Weightings** – Variant weightings in experiments now accept decimal values (e.g. 33.33%), removing the previous integer-only restriction. Weightings are still validated to sum to 100 (within a small float tolerance), and any unspecified variant weights are distributed evenly across the remaining share.
+- **Branch-Scoped Version Storage** – Version JSON files saved in the Builder are now stored under a branch-specific path (`{embeddableId}/{branchId}/version-{n}`) when a branch is active, preventing cross-branch version collisions in storage.
+</Update>
+
 <Update label="01 July 2025">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #1742.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other web app doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Experiment variant weightings now accept decimal values with automatic validation and distribution across unspecified variants.
  * Builder version files are now saved to branch-specific storage locations, eliminating conflicts when working across multiple branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->