### PR TITLE
Workers docs update (PR #203)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,13 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="01 April 2026">
+### 🐞 Bug Fixes
+
+- **Server-Side Rendering Compatibility** – The client-side JS bundle no longer overwrites server-rendered HTML when using the backend SSR integration. Interactive setup now proceeds correctly on top of pre-rendered content.
+- **Stripe Checkout Promo Codes** – Applying a promo code to one Stripe Checkout component no longer triggers session re-creation in other Stripe Checkout components on the same page, fixing errors on pages with multiple checkouts.
+</Update>
+
 <Update label="01 July 2025">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #203.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other workers doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with fixes: Server-Side Rendering now correctly preserves pre-rendered content when using client-side JS, and Stripe Checkout promo codes no longer cause unintended session updates across multiple checkouts on the same page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->