### PR TITLE
Add PR template and Cursor Cloud agent guidance (DEV-142)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+
+<!-- Briefly explain the problem or goal and what this change does. -->
+
+## Changes
+
+<!-- List the main changes. Link to related issues or docs pages when helpful. -->
+
+## Tests
+
+<!-- How you verified the change (e.g. `mintlify dev`, link check, spelling). -->
+
+## Related
+
+<!-- Link at least one of the following. -->
+
+- Linear: <!-- e.g. DEV-123 -->
+- GitHub issue: <!-- if applicable -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Embeddables documentation site
+
+This repository contains the **Embeddables** product documentation (Mintlify).
+
+For setup, preview, PR conventions, and **Cursor Cloud** workflow (branch base, PR body template), read **`AI-README.md`** at the repository root.

--- a/AI-README.md
+++ b/AI-README.md
@@ -1,0 +1,30 @@
+# Embeddables docs (`heysavvy/docs`)
+
+Internal guide for humans and AI assistants working on this repository. The published site is built with [Mintlify](https://mintlify.com/).
+
+## Local development
+
+1. Install Node.js (18.10+ recommended).
+2. Install the Mintlify CLI: `npm i -g mintlify`.
+3. From the repository root, run `mintlify dev` and open the local preview URL (default port 3000).
+
+Use `mintlify dev --port <port>` if the default port is in use.
+
+## Editing
+
+- Page content lives in `.mdx` files; navigation and metadata are in `docs.json`.
+- Follow the Mintlify component and frontmatter conventions described in `.cursor/rules/index.mdc` in this repo.
+
+## Pull requests
+
+- Base branch for new work: **`main`** (this repository’s default branch).
+- Use the repository PR template at `.github/pull_request_template.md` when you write the PR description. GitHub pre-fills it when you open a PR from the web UI; if you use automation or the API, paste the same sections (Description, Changes, Tests, Related) so reviewers get consistent context.
+- Link the driving **Linear** issue (for example `DEV-142`) in the Related section when the work came from Linear.
+
+## Cursor Cloud agents
+
+When a cloud agent runs against this repo (for example from a Linear assignment):
+
+- Create a working branch off `main` and open a PR back into **`main`** unless the task explicitly names another base branch.
+- Prefer branch names that match your team’s convention (for example `cursor/<short-description>-e2e4` when required by automation).
+- Register or update the PR using the template structure above so the description is not empty or generic.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replicates the mitigation from DEV-122 for this repository: a GitHub PR template on the default branch plus concise agent-oriented docs so Cursor Cloud runs against `heysavvy/docs` use a filled PR description and target **`main`**.

## Changes

- Added `.github/pull_request_template.md` (Description, Changes, Tests, Related with Linear/GitHub placeholders).
- Added `AI-README.md` with local Mintlify workflow, PR expectations, and explicit Cursor Cloud instructions (base branch `main`, use template structure when automation does not pre-fill).
- Added `AGENTS.md` as a short pointer to `AI-README.md`, matching the pattern used in other Embeddables repos.

## Testing

- Not run (Markdown-only; no build step required for content validation).

Linear: DEV-142
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEV-142](https://linear.app/embeddables/issue/DEV-142/replicate-pr-template-fix-in-docs-repo)

<div><a href="https://cursor.com/agents/bc-5a3f3956-e10b-48f7-907d-29bc452ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a3f3956-e10b-48f7-907d-29bc452ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

