### PR TITLE
Remove duplicate `embeddables branches create` accordion in CLI commands

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -438,14 +438,14 @@ description: "Complete reference for all Embeddables CLI commands and their opti
             <code>-i, --id &lt;id&gt;</code>
           </td>
           <td>
-            Embeddable ID (inferred from cwd or interactive prompt if not provided).
+            Embeddable ID. Inferred from the current working directory or automatically when run inside <code>embeddables/&lt;id&gt;/</code>; otherwise prompts to choose from local Embeddables if not provided.
           </td>
         </tr>
         <tr>
           <td>
             <code>-n, --name &lt;name&gt;</code>
           </td>
-          <td>Branch name (required). The success output will include the new branch ID returned by the server.</td>
+          <td>Branch name (required). The origin version and branch are read automatically from <code>config.json</code>. The success output includes the new branch ID returned by the server.</td>
         </tr>
       </tbody>
     </table>
@@ -910,30 +910,6 @@ description: "Complete reference for all Embeddables CLI commands and their opti
             <code>-b, --branch-id &lt;id&gt;</code>
           </td>
           <td>Branch ID to link to the task (required).</td>
-        </tr>
-      </tbody>
-    </table>
-  </Accordion>
-  <Accordion title="embeddables branches create">
-    <table>
-      <thead>
-        <tr>
-          <th>Option</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <code>-i, --id &lt;id&gt;</code>
-          </td>
-          <td>Embeddable ID (prompt from local Embeddables if not provided; inferred automatically if run from inside <code>embeddables/&lt;id&gt;/</code>).</td>
-        </tr>
-        <tr>
-          <td>
-            <code>-n, --name &lt;name&gt;</code>
-          </td>
-          <td>Branch name (required). The origin version and branch are read automatically from <code>config.json</code>.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DEV-187.

The Command options section in `cli/commands.mdx` contained two `<Accordion title="embeddables branches create">` blocks in the same group, which Mintlify rendered as duplicate entries. This change removes the second accordion and merges its unique option descriptions (ID resolution via cwd / `embeddables/<id>/` / local prompt; origin from `config.json`; success output includes branch ID) into the remaining accordion.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEV-187](https://linear.app/embeddables/issue/DEV-187/remove-duplicated-commandoption-accordion-in-branches-create-command)

<div><a href="https://cursor.com/agents/bc-474cf2d8-5e6b-40e3-bd7a-7bbd1fff34b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-474cf2d8-5e6b-40e3-bd7a-7bbd1fff34b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help descriptions for `embeddables branches create` command options
  * Clarified how the `-i/--id` option infers or prompts for the Embeddable ID
  * Specified that origin version and branch are read from `config.json`
  * Removed duplicate command documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->