### PR TITLE
CLI docs update v0.16.1

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.16.0** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.16.1** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,24 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.1 — 23 April 2026">
+
+### Features
+
+- **`disable_button_until_page_valid` for `StripeCheckout2`** — `StripeCheckout2` now accepts a `disable_button_until_page_valid` boolean prop. When set to `true`, the payment button stays disabled until all page-level validation passes, preventing premature payment attempts before required fields are complete.
+
+### Bug Fixes
+
+- **Workbench: removed nonexistent `setContentLanguage` call** — The Workbench language switcher was calling `window.Savvy.setContentLanguage()`, which does not exist in the engine. The no-op call has been removed; language switching continues to work correctly via `setUserData` with the language key.
+
+### Chores
+
+- **AI prompt rules: `window.Embeddables.trackCustomEvent`** — Consumer AI context updated to reference `window.Embeddables.trackCustomEvent()` for host-page custom event tracking, replacing the legacy `window.Savvy.trackCustomEvent()` reference.
+- **AI prompt rules: legacy `experiments` array prohibited** — Consumer AI context now explicitly prohibits writing the top-level `experiments` array on a Flow. `connected_experiments` is the only field AI agents may write for experiment connections, preventing experiments from disappearing from the Experiments UI.
+- **Supabase local development stack** — Added Supabase configuration, schema migrations, seed data, generated database types, and a typed Supabase client for internal development. No user-facing changes.
+
+</Update>
+
 <Update label="v0.16.0 — 3 April 2026">
 
 ### Features

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -25,7 +25,6 @@ Check your version: `embeddables -v`
 
 - **AI prompt rules: `window.Embeddables.trackCustomEvent`** — Consumer AI context updated to reference `window.Embeddables.trackCustomEvent()` for host-page custom event tracking, replacing the legacy `window.Savvy.trackCustomEvent()` reference.
 - **AI prompt rules: legacy `experiments` array prohibited** — Consumer AI context now explicitly prohibits writing the top-level `experiments` array on a Flow. `connected_experiments` is the only field AI agents may write for experiment connections, preventing experiments from disappearing from the Experiments UI.
-- **Supabase local development stack** — Added Supabase configuration, schema migrations, seed data, generated database types, and a typed Supabase client for internal development. No user-facing changes.
 
 </Update>
 


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.16.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StripeCheckout2 can keep the payment button disabled until page validation completes
  * Consumer AI prompt rules updated to recommend using window.Embeddables.trackCustomEvent() and require flows to write connected_experiments instead of the top-level experiments array

* **Bug Fixes**
  * Workbench language switcher now correctly applies language changes

* **Documentation**
  * Released CLI version 0.16.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->