### PR TITLE
Workers docs update (PR #241)

### DIFF
--- a/features/stripe-payments.mdx
+++ b/features/stripe-payments.mdx
@@ -302,6 +302,24 @@ These features are not required in order to successfully accept payments, but th
     </Warning>
 
   </Accordion>
+  <Accordion title="Disable the Pay button until the page is valid">
+    When `disable_button_until_page_valid` is set to `true` on a Stripe Checkout 2 component, the Pay button is disabled reactively whenever any required field on the current page is incomplete or invalid. The button re-enables as soon as all required fields are satisfied.
+
+    This is different from `enforce_validation`, which only blocks the payment attempt at the moment the user clicks Pay. With `disable_button_until_page_valid` the button itself is visually disabled throughout, giving users an immediate cue that they still need to fill something in.
+
+    **How to enable it:**
+    1. In the Builder, select the Stripe Checkout 2 component.
+    2. Open the component's JSON editor and add `"disable_button_until_page_valid": true`.
+
+    <Tip>
+      You can style the disabled state however you like using CSS targeting `[disabled]` on the Pay button element. No default disabled style is applied — full control is yours.
+    </Tip>
+
+    <Note>
+      This setting works in conjunction with the existing `enforce_validation` option. If you only want to block the payment attempt (without visually disabling the button beforehand), use `enforce_validation: true` without setting `disable_button_until_page_valid`.
+    </Note>
+
+  </Accordion>
   <Accordion title="Place a hold on the customer's card">
     See the [How To: Place a Hold on a Payment](/how-to/place-a-hold-on-payment) guide for more information on this feature.
 

--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -9,7 +9,6 @@ icon: "list"
 
 - 🎬 **`triggerAction` on `window.Embeddables`** – `triggerAction` is now available on `window.Embeddables` in addition to `window.Savvy`, so you can fire any named action in your Embeddable directly from the host page using either alias.
 - 💳 **Disable Pay Button Until Page Is Valid** – A new `disable_button_until_page_valid` property on the Stripe Checkout 2 component reactively disables the Pay button whenever required page fields are incomplete, giving users an immediate visual cue rather than waiting until they click Pay.
-- 🔬 **Workbench Branch Preview URL** – A new `workbench_domain` query parameter lets you point the Workbench to a custom engine branch preview URL (must use HTTPS and end with `heysavvy.workers.dev`), making it easier to test Workbench changes against a specific engine branch.
 
 ### 🐞 Bug Fixes
 

--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,18 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="23 April 2026">
+### 🔥 Features and Updates
+
+- 🎬 **`triggerAction` on `window.Embeddables`** – `triggerAction` is now available on `window.Embeddables` in addition to `window.Savvy`, so you can fire any named action in your Embeddable directly from the host page using either alias.
+- 💳 **Disable Pay Button Until Page Is Valid** – A new `disable_button_until_page_valid` property on the Stripe Checkout 2 component reactively disables the Pay button whenever required page fields are incomplete, giving users an immediate visual cue rather than waiting until they click Pay.
+- 🔬 **Workbench Branch Preview URL** – A new `workbench_domain` query parameter lets you point the Workbench to a custom engine branch preview URL (must use HTTPS and end with `heysavvy.workers.dev`), making it easier to test Workbench changes against a specific engine branch.
+
+### 🐞 Bug Fixes
+
+- The Stripe Checkout 2 pay button's `disabled` HTML attribute is now set to `"disabled"` instead of `"true"`, aligning with the HTML spec and ensuring consistent behaviour across all browsers and CSS selectors.
+</Update>
+
 <Update label="16 April 2026">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #241.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other workers doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe Checkout 2: Added an option to reactively disable the Pay button until current-page required fields are valid.
  * `triggerAction` now exposed on window.Embeddables.

* **Bug Fixes**
  * Fixed Stripe Checkout 2 pay button disabled-state behavior so the button is properly marked disabled.

* **Documentation**
  * Added docs and changelog entries describing the new Stripe option and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->