### PR TITLE
Web App docs update (PR #1979)

### DIFF
--- a/features/design.mdx
+++ b/features/design.mdx
@@ -136,6 +136,12 @@ Different component types have specialized elements:
     label** - Secondary label text - **File list** - List of uploaded files -
     **File item** - Individual file in the list
   </Accordion>
+  <Accordion title="Progress Bar elements">
+    - **Whole thing** - The entire progress bar container - **Bar filled** - The
+    filled portion of the bar - **Progress text** - The progress label or
+    percentage text - **Reset button** - The reset control inside the progress
+    bar
+  </Accordion>
   <Accordion title="Stripe Checkout elements">
     - **Payment box** - Container for payment form - **Payment form** - The form
     element - **Stripe checkout button** - Submit button - **Message list** -

--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,17 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="07 May 2026">
+### 🔥 Features and Updates
+
+- 🛑 **Cancel QA Runs** – Running QA runs can now be cancelled directly from the runs list. Open the run's actions menu and choose **Cancel run** to stop the worker; the run is then marked as **Cancelled**, which appears as a badge on the run and as a new option in the QA runs status filter dropdown.
+- 📊 **Progress Bar Styling Selectors** – The Progress Bar component now exposes two additional styling elements in the Design sidebar — **Progress text** and **Reset button** — so you can style the progress label and reset control independently from the bar.
+
+### 🐞 Bug Fixes
+
+- Reordering conversion events no longer drops the payload metric keys attached to each conversion.
+  </Update>
+
 <Update label="23 April 2026">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #1979.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other web app doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Progress Bar element selectors to design docs, listing selectable sub‑elements (whole thing, bar filled, progress text, reset button).

* **New Features**
  * Added ability to cancel QA runs with a "Cancelled" status badge and filter.
  * Added styling selectors for Progress Bar progress text and reset button.

* **Bug Fixes**
  * Fixed reordering of conversion events dropping attached payload metric keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->