### PR TITLE
Web App docs update (PR #2031)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,29 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="18 May 2026">
+### 🔥 Features and Updates
+
+- 📝 **Docs: Briefings, Context, and Templates** – A new **Docs** area in the project sidebar lets teams capture long-form context documents about their product, define reusable MDX briefing templates (with a mock-data preview), and generate briefings on demand. Briefings render with rich MDX components — **Callout**, **Tooltip**, **Link buttons**, **Overline**, **BadgePercentage**, and typed **Table** columns with optional header/cell tooltips — and can be exported to PDF from the briefing detail page. Available per project via the new `include_briefings` project setting.
+- 🔌 **New analytics & docs endpoints** – Internal API endpoints have been added to power the CLI and Trigger.dev briefing-generation jobs: document templates (list/create/save/update-status), context docs, briefing creation, plus `POST /api/analytics/experiment-result`, `POST /api/analytics/funnel`, `POST /api/metrics`, and `POST /api/goals`. All are protected by the internal `x-api-key` header.
+
+### ⚡️ Improvements
+
+- **Friendlier Created column in the Briefings table** – Briefing creation timestamps now display in the project's timezone with a readable format such as "May 14, 2026, 5 PM" instead of a raw UTC timestamp.
+- **Per-template briefing ordinals in titles** – Briefing rows now show a muted `#n` next to each title indicating the chronological position within its template group, making it easier to scan generations of the same template.
+- **Real links throughout the Briefings UI** – Briefing and template table rows now navigate via real Next.js links, so right-click → open in new tab and middle-click work as expected.
+- **Graceful degradation for unknown MDX components** – The MDX renderer no longer crashes when a template references a component that isn't in the registry; unknown components are rendered as a visible placeholder so the rest of the briefing still loads.
+- **No more full-page reload on template edit** – Editing a document template now updates the preview in place instead of forcing a full route reload.
+- **List-route skeletons for Docs** – Briefings, Context, and Templates list routes now have proper `loading.tsx` skeletons, eliminating the navigation freeze when switching tabs.
+
+### 🐞 Bug Fixes
+
+- The QA tests table no longer shows a stale failed run as the **Latest Result** after a successful re-run — embedded QA runs are now ordered and limited at the database level so the most recent run is always picked.
+- Briefing PDF exports no longer overflow the page width when the briefing title is long.
+- The briefing, template, and context-doc detail pages no longer scroll the entire page; scrolling is now contained to the document body.
+- Mock-data preview of templates no longer produces invalid MDX (table cells are normalised so the preview matches the exported PDF).
+  </Update>
+
 <Update label="23 April 2026">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #2031.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other web app doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Briefings sidebar with MDX templates, mock-data previews, on-demand generation, in-place template preview updates, and PDF export; new project setting to enable briefings
  * New analytics & docs API endpoints (secured)
  * UI improvements: timezone-formatted Created column, per-template ordinals, real links, graceful handling of unknown MDX components, and loading skeletons

* **Bug Fixes**
  * Fixed QA selection ordering, PDF title overflow, document-body scroll containment, and mock-data preview normalization for exported PDFs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->