### PR TITLE
CLI docs update v0.16.4

### DIFF
--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,18 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.4 — 18 May 2026">
+
+### Improvements
+
+- **`doc-templates` commands point to production** — `embeddables doc-templates create`, `save`, and `update-status` now call the production web app at `WEB_APP_BASE_URL` instead of the temporary staging-briefings Vercel preview. The deprecated `DOC_TEMPLATES_WEB_APP_BASE_URL` override has been removed.
+
+### Chores
+
+- **Briefings AI prompt: `uppercase-heading` CSS class** — The doc-templates AI prompt context (`.prompts/doc-templates-AI-README.md`) now references the `uppercase-heading` class (hyphen) instead of the legacy `uppercase_heading` (underscore) for column-style section labels in Briefings templates.
+
+</Update>
+
 <Update label="v0.16.1 — 23 April 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.16.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Document template commands now use the correct production base URL, fixing URL configuration.

* **Chores**
  * Briefings AI prompt context updated to reference the hyphenated heading CSS class for consistent styling.

* **Documentation**
  * Added changelog entry for v0.16.4 (18 May 2026).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->