### PR TITLE
Web App docs update (PR #2036)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,19 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="19 May 2026">
+### 🔥 Features and Updates
+
+- 📄 **Briefings Design Refresh** – Briefings documents now use a dedicated design system with refined typography, scoped heading styles, and a polished card/status look. Headings (`h1`/`h2`/`h3`) render at larger, more readable sizes inside Briefings without affecting the rest of the app.
+- 🏷️ **Restyled `<Overline>` Section Labels** – The `<Overline>` MDX component now renders as a bold uppercase label paired with a horizontal divider line, making section breaks in Briefings clearer at a glance.
+
+### ⚡️ Improvements
+
+- **New `size` Prop on `<Table>`** – The MDX `<Table>` component now accepts an optional `size` prop (`"regular"` or `"small"`). Choose `"small"` for tighter cell padding and a more compact header in dense data tables; `"regular"` remains the default.
+- **Reusable Briefings Design Tokens** – New utility classes (`uppercase-heading`, `uppercase-heading-bold`, `mono-base`, `card`, `card--lg`, `card--breakdown`, `status-dot`, `status-dot-pulse`) are available inside the `briefings-design` MDX context for consistent styling across Briefings documents.
+- **Dynamic MDX Class Safelist** – Tailwind now safelists common spacing, gap, font, and box utilities used in dynamic Briefings MDX content, preventing classes from being tree-shaken when they only appear in CMS-authored documents.
+</Update>
+
 <Update label="23 April 2026">
 ### 🔥 Features and Updates
 

--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -21,6 +21,7 @@ icon: "list"
 - **New `size` Prop on `<Table>`** – The MDX `<Table>` component now accepts an optional `size` prop (`"regular"` or `"small"`). Choose `"small"` for tighter cell padding and a more compact header in dense data tables; `"regular"` remains the default.
 - **Reusable Briefings Design Tokens** – New utility classes (`uppercase-heading`, `uppercase-heading-bold`, `mono-base`, `card`, `card--lg`, `card--breakdown`, `status-dot`, `status-dot-pulse`) are available inside the `briefings-design` MDX context for consistent styling across Briefings documents.
 - **Dynamic MDX Class Safelist** – Tailwind now safelists common spacing, gap, font, and box utilities used in dynamic Briefings MDX content, preventing classes from being tree-shaken when they only appear in CMS-authored documents.
+- **Page Traffic Analytics Endpoint** – A new internal `/api/analytics/page-traffic` endpoint returns unique-contact traffic per page for an embeddable, with optional response-based breakdowns, `responses:*` filters, and page-key whitelisting. Powers downstream sub-agents and automation jobs that need page-level traffic without the funnel route's drop-off post-processing.
 </Update>
 
 <Update label="18 May 2026">


### PR DESCRIPTION
Auto-generated docs update following merge of PR #2036.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other web app doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed Briefings design and updated section labeling
  * Table supports an optional size setting
  * Added page-traffic analytics endpoint

* **Updates**
  * Overline styling refreshed for consistency
  * New reusable design tokens for Briefings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->