### PR TITLE
CLI docs update v0.16.5

### DIFF
--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,17 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.5 — 19 May 2026">
+
+### Chores
+
+- **AI prompt rules: Briefings design system tokens** — Consumer AI context for Briefings doc templates expanded with new CSS utility classes: `uppercase-heading-bold`, `mono-base`, `subheading`, `subheading-2`, `headline-stat`, `card` (plus `card--lg` and `card--breakdown` variants), and `status-dot` / `status-dot-pulse` indicators. Lets AI agents author Briefings templates with the full design-system vocabulary instead of falling back to inline styles.
+- **AI prompt rules: `Table` `size` prop** — Doc-template AI context now documents the new `size?: 'regular' | 'small'` prop on `<Table>`. Use `"small"` for dense layouts or tables nested inside cards; defaults to `"regular"`.
+- **AI prompt rules: SVG donut seam warning** — Doc-template AI context now warns against building donut charts from stacked `<circle stroke-dasharray>` elements (they produce seam artifacts at slice boundaries). AI agents are directed to use `<DonutGraph>` or, if custom SVG is required, draw each slice as a filled `<path>` annulus wedge.
+- **AI prompt rules: `uppercase-heading` class name** — Doc-template AI context renamed the `uppercase_heading` CSS class to `uppercase-heading` (hyphenated) to match the actual Briefings stylesheet, preventing AI-generated templates from emitting an unrecognised class name.
+
+</Update>
+
 <Update label="v0.16.1 — 23 April 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.16.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added changelog entry v0.16.5
  * Expanded design-system CSS utilities for Briefings (card variants and status-dot indicators)
  * Documented Table component size options (regular | small)
  * Advised against constructing SVG donut charts via stacked circle stroke-dasharray seams
  * Renamed CSS class to uppercase-heading (hyphenated); may require style updates for custom implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->