### PR TITLE
CLI docs update v0.16.6

### DIFF
--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,18 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.6 — 19 May 2026">
+
+### Bug Fixes
+
+- **Global component insert positions in JSON diff → edit history** — Fixed `src/helpers/json.ts` so that insert anchors for components added in a diff are scoped by their `_location` (global slot vs. page-level bucket). Sibling ordering now uses only true ordering peers (same parent or same `_location`), the `isGlobalComponents` flag is passed for root globals, and `insertedComponentId` is excluded from anchor resolution so a component can never anchor against itself. Move-command logic was also tightened to preserve component hierarchy across global slots.
+
+### Chores
+
+- **AI prompt rules: MdxRenderer heading styles** — Internal `.prompts/doc-templates-AI-README.md` now documents the default heading styles automatically applied by `MdxRenderer`: `# H1` → `text-3xl`, `## H2` → `text-2xl`, and `### H3` → `text-lg`, all medium weight with `text-primary-color`. This gives AI agents accurate context when authoring doc-template MDX.
+
+</Update>
+
 <Update label="v0.16.1 — 23 April 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.16.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.16.6

* **Bug Fixes**
  * Fixed component ordering in JSON diff edit-history for global and page-level components.

* **Chores**
  * Updated internal documentation for markdown rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->