### PR TITLE
Web App docs update (PR #2053)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,12 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="21 May 2026">
+### ⚡️ Improvements
+
+- 🌍 **Project Region API for Internal Services** – A new `POST /api/projects/region` endpoint lets trusted server-side services (such as Trigger.dev jobs and sub-agents) look up a project's configured timezone region and its offset in minutes without needing a user session. Authenticated via the `x-api-key` header against the shared internal API key, it returns `{ region, offsetInMinutes }` — falling back to `America/Los_Angeles` when no region is set — so background jobs can perform date/time work in the project's timezone.
+  </Update>
+
 <Update label="23 April 2026">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #2053.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other web app doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changelog updated (21 May 2026) documenting improvements to project timezone reporting: projects now expose a region and minute-based UTC offset, with a fallback default of America/Los_Angeles when no region is configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->