### PR TITLE
CLI docs update v0.16.2 (without doc-templates)

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.16.1** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.16.2** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,18 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.2 — 6 May 2026">
+
+### Improvements
+
+- **Per-operation edit history on save and publish** — `embeddables save` and `embeddables dangerously-publish` now emit per-change `editHistoryDescriptions` matching the Builder's format (e.g. `Set component login_btn [id: comp_123] property text to "Continue"`, `Add component cta_button in page welcome`, `Move page checkout`, `Remove tag draft from Page welcome`). Previously each save/publish recorded a single generic `Saved version from CLI` entry. Descriptions are capped at 100 entries with an overflow marker, mirroring the Builder. The `trigger.editor` field on save/publish now records the actual user ID instead of the literal string `"CLI"`.
+
+### Chores
+
+- **AI-README: PR title workflow for Linear issues** — Internal contributor guide updated with the PR title format used for Linear-tracked work.
+
+</Update>
+
 <Update label="v0.16.1 — 23 April 2026">
 
 ### Features


### PR DESCRIPTION
## Summary

- Bumps the documented CLI version to **0.16.2** in `cli/overview.mdx`.
- Adds a filtered **v0.16.2** changelog entry with only the edit-history improvement and the Linear PR title workflow chore.
- Excludes all doc-templates documentation until that feature is ready to publish.

This replaces [#105](https://github.com/heysavvy/docs/pull/105) for merge to `main` — no changes to `cli/commands.mdx`, and no doc-templates content in overview or changelog.

## Test plan

- [ ] Verify Mintlify preview renders the updated version badge on the CLI overview page.
- [ ] Confirm the v0.16.2 changelog entry shows Improvements and Chores only (no Features, no doc-templates chore).
- [ ] Confirm `cli/commands.mdx` is unchanged vs `main`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation to version 0.16.2

* **New Features**
  * Introduced per-operation edit history tracking for save and publish operations
  * Enhanced edit history descriptions with improved formatting and overflow handling
  * Improved operation trigger tracking to record actual user IDs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->