### PR TITLE
CLI docs update v0.16.3 (without doc-templates)

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.16.2** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.16.3** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,14 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.3 — 18 May 2026">
+
+### Chores
+
+- **PR template: Decisions section** — The repo's pull request template now leads with a `Decisions` section capturing approach, tradeoffs, and alternatives so reviewers see key decisions at the top of the PR. Contributor-facing only.
+
+</Update>
+
 <Update label="v0.16.2 — 6 May 2026">
 
 ### Improvements


### PR DESCRIPTION
## Summary

- Bumps the documented CLI version to **0.16.3** in `cli/overview.mdx`.
- Adds a filtered **v0.16.3** changelog entry with only the PR template `Decisions` section chore.
- Excludes all doc-templates documentation until that feature is ready to publish.

This replaces [#110](https://github.com/heysavvy/docs/pull/110) for merge to `main` — no changes to `cli/commands.mdx`, and no doc-templates content in overview or changelog.

## Test plan

- [ ] Verify Mintlify preview renders the updated version badge on the CLI overview page.
- [ ] Confirm the v0.16.3 changelog entry shows Chores only (no Features, Improvements, or doc-templates chore).
- [ ] Confirm `cli/commands.mdx` is unchanged vs `main`.


Made with [Cursor](https://cursor.com)