### PR TITLE
CLI docs update v0.16.6 (without doc-templates)

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.16.3** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.16.6** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,14 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.6 — 19 May 2026">
+
+### Bug Fixes
+
+- **Global component insert positions in JSON diff → edit history** — Fixed `src/helpers/json.ts` so that insert anchors for components added in a diff are scoped by their `_location` (global slot vs. page-level bucket). Sibling ordering now uses only true ordering peers (same parent or same `_location`), the `isGlobalComponents` flag is passed for root globals, and `insertedComponentId` is excluded from anchor resolution so a component can never anchor against itself. Move-command logic was also tightened to preserve component hierarchy across global slots.
+
+</Update>
+
 <Update label="v0.16.3 — 18 May 2026">
 
 ### Chores


### PR DESCRIPTION
## Summary

- Bumps the documented CLI version to **0.16.6** in `cli/overview.mdx`.
- Adds a filtered **v0.16.6** changelog entry with only the global component insert positions bug fix.
- Excludes the doc-templates AI prompt rules chore until that workflow is ready to document.

This replaces [#115](https://github.com/heysavvy/docs/pull/115) for merge to `main` — no changes to `cli/commands.mdx`, and no doc-templates content in the changelog.

## Test plan

- [ ] Verify Mintlify preview renders the updated version badge on the CLI overview page.
- [ ] Confirm the v0.16.6 changelog entry shows Bug Fixes only (no doc-templates chore).
- [ ] Confirm `cli/commands.mdx` is unchanged vs `main`.


Made with [Cursor](https://cursor.com)