### PR TITLE
Web App docs update PR #2007 (without briefings)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -16,6 +16,12 @@ icon: "list"
 - ♿ **Accessibility: Focus Moves to Top on Page Change** – When a flow advances to a new page and scrolls to the top, focus is now programmatically moved to the form at the top of the page so screen readers and keyboard users land in the right place. Focus only moves when the embed itself scrolls (not when the document scrolls), and the programmatic focus ring is suppressed so sighted users don't see an unexpected outline on every page change.
 </Update>
 
+<Update label="13 May 2026">
+### 🐞 Bug Fixes
+
+- **Experiment Results Contact Matching** – The experiment results query now includes `contact_id` in its joins and groups by both `entry_id` and `contact_id`, fixing inconsistent or duplicated rows that could appear when the same contact had multiple entries.
+</Update>
+
 <Update label="07 May 2026">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
## Summary

- Adds a filtered **13 May 2026** entry to `reference/changelog/changelog.mdx` with only the experiment results contact matching bug fix.
- Excludes all Briefings, doc templates, and MDX component library content until that workflow is ready to document.

This replaces [#107](https://github.com/heysavvy/docs/pull/107) for merge to `main`.

## Test plan

- [ ] Verify Mintlify preview renders the new changelog entry in the correct order (between 18 May and 07 May).
- [ ] Confirm the entry shows Bug Fixes only (no Features, Improvements, or briefing-related fixes).


Made with [Cursor](https://cursor.com)