### PR TITLE
Web App docs update PR #2031 (without briefings)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -14,6 +14,10 @@ icon: "list"
 ### ⚡️ Improvements
 
 - ♿ **Accessibility: Focus Moves to Top on Page Change** – When a flow advances to a new page and scrolls to the top, focus is now programmatically moved to the form at the top of the page so screen readers and keyboard users land in the right place. Focus only moves when the embed itself scrolls (not when the document scrolls), and the programmatic focus ring is suppressed so sighted users don't see an unexpected outline on every page change.
+
+### 🐞 Bug Fixes
+
+- The QA tests table no longer shows a stale failed run as the **Latest Result** after a successful re-run — embedded QA runs are now ordered and limited at the database level so the most recent run is always picked.
 </Update>
 
 <Update label="13 May 2026">


### PR DESCRIPTION
## Summary

- Adds the QA **Latest Result** bug fix to the existing **18 May 2026** changelog entry (no duplicate date block).
- Excludes all Briefings, doc templates, MDX, and docs API content until that workflow is ready to document.

This replaces [#109](https://github.com/heysavvy/docs/pull/109) for merge to `main`.

## Test plan

- [ ] Verify Mintlify preview shows a single 18 May entry with Improvements and Bug Fixes.
- [ ] Confirm no Briefings, Context, Templates, or doc-templates features are listed.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed QA tests table incorrectly displaying stale failed runs as the latest result after a successful re-run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->