### PR TITLE
Web App docs update PR #2047 (without briefings)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,12 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="20 May 2026">
+### 🔥 Features and Updates
+
+- 🌐 **Browser Filter on Users List** – The Users page now has a **Browser** filter to narrow down contacts by browser (Chrome, Firefox, Safari, etc.). The filter is multi-select, syncs with the URL so filtered views are shareable, and uses the same UAParser-based browser names as the Device column.
+</Update>
+
 <Update label="19 May 2026">
 ### ⚡️ Improvements
 


### PR DESCRIPTION
## Summary

- Adds a filtered **20 May 2026** entry to `reference/changelog/changelog.mdx` with only the **Browser Filter on Users List** feature.
- Excludes document template scheduling, frequency badges, and briefings tracking until that workflow is ready to document.

This replaces [#117](https://github.com/heysavvy/docs/pull/117) for merge to `main`.

## Test plan

- [ ] Verify Mintlify preview shows the 20 May entry in chronological order (above 19 May).
- [ ] Confirm the entry shows Features only with the Browser filter (no template or briefings items).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a multi-select Browser filter to the Users list, enabling filtering of contacts by browser type.
  * Filter selections sync with the URL for easy sharing of filtered views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->