### PR TITLE
CLI docs update v0.16.7

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -16,7 +16,7 @@ description: "Build and manage Embeddables locally with code — for developers 
 </Warning>
 
 <Info>
-  **Current version: 0.16.6** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
+  **Current version: 0.16.7** — See the [CLI Changelog](/reference/changelog/cli-changelog) for what's new.
 </Info>
 
 The Embeddables CLI lets you build, edit, and manage Embeddables using **code** instead of (or alongside) the web Builder. It turns Embeddables into **TypeScript/TSX** you can edit in any editor, with **hot reload** and strong support for **AI assistants** (Cursor, Claude, etc.).

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,20 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.7 — 27 May 2026">
+
+### Features
+
+- **Workbench: page thumbnail strip** — A new toggleable thumbnail row below the Workbench shows a preview of every page in the Embeddable, with the current page highlighted and auto-centered. Click a thumbnail to jump via `Savvy.goToPage`; drag the divider to resize the strip. Thumbnails use the Engine's static HTML when available and derive their viewport from the Flow's breakpoints, and pages hidden or gated by unmet conditions or experiments are dimmed in both the page navigator dropdown and the thumbnail row. Strip visibility and height persist in `WorkbenchPrefs` (localStorage), the list is virtualized with `@tanstack/react-virtual`, and the strip is hidden by default.
+- **Workbench: action-debug toast toggle** — A new bolt button in the Workbench toggles action-debug toasts on/off and syncs the `savvy_debug` URL param (preserving `history.state` and removing the param on toggle-off so a reload reflects the new state). Includes `aria-label`/`aria-pressed` for accessibility.
+
+### Chores
+
+- **AI prompt rules: Actions and multilingual guidance** — Consumer AI context now documents the full `output()` second-arg helper API (`setUserData`, `goToPage`, `goToNextPage`, `trackCustomEvent`) with destructuring examples, clarifies that computed fields typically only use `trackCustomEvent`, and adds Flow-level `languages` config plus end-user runtime language behavior (browser-locale scope in published runtime, exact vs regional key matching, opt-in `outputs_onloadflow` defaults). The global language picker is reframed as a stakeholder-driven, design-agnostic pattern (any UI that sets `embeddable_language`; `OptionSelector` shown as one common example).
+- **doc-templates AI README: Markdown and JSX typography** — Internal doc-templates AI context clarifies Markdown vs JSX usage in typography: documents automatic class application for standard HTML headings/paragraphs and the explicit JSX requirements for custom styling, with an improved table layout.
+
+</Update>
+
 <Update label="v0.16.6 — 19 May 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.16.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.16.7

* **New Features**
  * Added toggleable page thumbnail strip in Workbench.
  * Added action-debug toast toggle with URL parameter sync capability.

* **Documentation**
  * Updated CLI documentation to reflect latest version.
  * Enhanced AI prompt rules documentation for the `output()` API and multilingual runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heysavvy/docs/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->