### PR TITLE
CLI docs update v0.16.9

### DIFF
--- a/cli/development.mdx
+++ b/cli/development.mdx
@@ -12,6 +12,7 @@ description: "Dev server, Workbench, TypeScript authoring, and workflows for tec
 - Serves the compiled Embeddable to the Engine at the **Preview URL**.
 - Watches files under `embeddables/<id>/` and recompiles on change (hot reload).
 - By default uses the **production** Engine (`https://engine.embeddables.com`); use `--local` to point to a local engine (e.g. `http://localhost:8787`).
+- Forwards your project ID to the Engine, so **connected experiments resolve** and `split_*` variant keys are assigned in the preview just like they are in production.
 
 The terminal prints a URL like:
 

--- a/reference/changelog/cli-changelog.mdx
+++ b/reference/changelog/cli-changelog.mdx
@@ -11,6 +11,18 @@ Check your version: `embeddables -v`
 
 ---
 
+<Update label="v0.16.9 — 3 June 2026">
+
+### Bug Fixes
+
+- **`embeddables dev`: connected experiments now resolve in local preview** — The dev proxy now forwards `projectId` to the Engine's `/init` request (in the `forcedJson` body), so connected experiments are resolved and `split_*` variant keys are assigned when previewing locally with `embeddables dev`. Previously `projectId` was omitted, so experiment variants and their split keys did not apply in the CLI preview.
+
+### Chores
+
+- **PR template: simplified** — The repo's pull request template was streamlined: the Description and Changes sections were merged into a single Summary, the Workbench preview and Examples/Files subsections were removed, the Tests and "How to test" guidance was simplified, and the checklist was updated for unit/E2E tests and UI screen recordings. Contributor-facing only.
+
+</Update>
+
 <Update label="v0.16.7 — 27 May 2026">
 
 ### Features


### PR DESCRIPTION
Auto-generated docs update following a new CLI publish.

- Changelog updated in `reference/changelog/cli-changelog.mdx`
- Other CLI doc pages reviewed and updated where relevant

Version: v0.16.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Connected experiments now correctly resolve in development preview
  * Experiment variant keys assign consistently with production behavior during local testing

* **Documentation**
  * Updated development guide to clarify experiment resolution behavior in the preview environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->