### PR TITLE
DEV-892: Update CLI docs to require Node 20

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -30,7 +30,7 @@ The Embeddables CLI lets you build, edit, and manage Embeddables using **code** 
 
 ## Requirements
 
-- **Node.js** >= 18.0.0
+- **Node.js** >= 20.0.0
 
 <AccordionGroup>
   <Accordion title="Installing Node.js and NPM on macOS">

--- a/cli/troubleshooting.mdx
+++ b/cli/troubleshooting.mdx
@@ -20,7 +20,7 @@ description: "Fix common CLI errors and learn about current limitations"
 
 <AccordionGroup>
   <Accordion title="I don't have Node.js or NPM installed">
-    The Embeddables CLI requires Node.js version 18.0.0 or higher (which includes NPM). See the [Installation instructions in the Overview](/cli/overview#requirements) for step-by-step setup guides for macOS and Windows.
+    The Embeddables CLI requires Node.js version 20.0.0 or higher (which includes NPM). See the [Installation instructions in the Overview](/cli/overview#requirements) for step-by-step setup guides for macOS and Windows.
   </Accordion>
   <Accordion title="'npm' is not recognized as an internal or external command (Windows)">
     This error means Node.js and NPM are not installed, or not in your system PATH. See the [Installation instructions in the Overview](/cli/overview#requirements) for how to install Node.js and NPM on Windows. After installing, restart your terminal or Command Prompt.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Embeddables CLI documentation to reflect the correct minimum Node.js version. A CLI dependency requires Node 20, but the docs still stated Node 18 was sufficient.

## Changes

- **`cli/overview.mdx`**: Updated the Requirements section from `Node.js >= 18.0.0` to `Node.js >= 20.0.0`.
- **`cli/troubleshooting.mdx`**: Updated the "I don't have Node.js or NPM installed" accordion from `18.0.0 or higher` to `20.0.0 or higher`.

## Verification

- Searched the docs repo for other CLI-related Node 18 references; only these two files needed updates.
- The root `development.mdx` Node 18 references are for Mintlify docs development tooling, not the Embeddables CLI, and were left unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEV-892](https://linear.app/embeddables/issue/DEV-892/update-cli-docs-to-require-node-20)

<div><a href="https://cursor.com/agents/bc-a311573b-dced-45b0-8d71-af1839336b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a311573b-dced-45b0-8d71-af1839336b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the minimum Node.js version requirement to 20.0.0 or higher for the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->