### PR TITLE
Workers docs update (PR #293)

### DIFF
--- a/features/stripe-payments.mdx
+++ b/features/stripe-payments.mdx
@@ -356,6 +356,16 @@ These features are not required in order to successfully accept payments, but th
       If you choose to create customers, you can collect the Customer ID using the [Collect Stripe IDs](#collect-stripe-ids-to-send-to-your-backend) feature.
     </Tip>
 
+    **Reusing existing customers by email**
+
+    By default, when an email is available Embeddables looks up Stripe for an existing customer with that email and attaches the newest matching customer to the Checkout Session. This means returning users can have a previously-created customer reused even when **Create a Customer in Stripe** is set to **If Required**.
+
+    To turn this off, set `disable_reuse_existing_stripe_customer_by_email` to `true` on the Stripe Checkout component (via its JSON editor). When enabled, Embeddables skips the email lookup entirely and never attaches an existing customer, so each session starts without a pre-existing customer attached.
+
+    <Note>
+      This only changes whether an *existing* customer is reused. Whether a *new* customer is created is still controlled by the **Create a Customer in Stripe** option above.
+    </Note>
+
   </Accordion>
   <Accordion title="Customise the Pay button text and Success message">
     You can customise both the label on the Pay button and the message shown to users after a successful payment.

--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -7,6 +7,16 @@ icon: "list"
 <Update label="23 June 2026">
 ### 🔥 Features and Updates
 
+- 💳 **Opt Out of Reusing Existing Stripe Customers** – Stripe Checkout components now support a `disable_reuse_existing_stripe_customer_by_email` option. When set to `true`, Embeddables skips looking up an existing Stripe customer by email before creating the Checkout Session, so returning users no longer have a previously-created customer attached to setup-mode sessions — even when **Create a Customer in Stripe** is set to **If Required**. Default behavior is unchanged: the newest matching customer is still reused when an email is available.
+
+### 🐞 Bug Fixes
+
+- 📜 **Scroll to Top on iOS Safari** – Fixed the scroll-to-top on page change being cancelled on iOS Safari. The engine now defers the scroll until after the page's HTML has been swapped (listening for the `embeddables:page_change_html_updated` event, with a 400ms fallback) and clears any stacked scroll listeners, so navigating between pages reliably scrolls to the top.
+</Update>
+
+<Update label="23 June 2026">
+### 🔥 Features and Updates
+
 - 💳 **Stripe Checkout Mounted & Unmounted Triggers** – Stripe Checkout components now expose **mounted** and **unmounted** lifecycle events in the Builder's Logic tab, alongside the existing payment events. Add a trigger to a Stripe Checkout component to run an Action when the component is mounted (loaded onto the page) or unmounted (removed from the page). The new triggers appear with readable labels in the trigger cards and layer tooltips.
 
 ### 🐞 Bug Fixes


### PR DESCRIPTION
Auto-generated docs update following merge of PR #293.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other workers doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to disable automatic reuse of existing Stripe customers by email during Checkout Session creation.

* **Bug Fixes**
  * Fixed iOS Safari scroll-to-top behavior on page navigation.

* **Documentation**
  * Updated Stripe payment configuration documentation with new customer reuse settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->