### PR TITLE
Web App docs update (PR #2145)

### DIFF
--- a/reference/changelog/changelog.mdx
+++ b/reference/changelog/changelog.mdx
@@ -4,6 +4,24 @@ description: "What we've shipped, when we shipped it"
 icon: "list"
 ---
 
+<Update label="29 June 2026">
+### 🔥 Features and Updates
+
+- 🧹 **Workspace Features Clean-Up** – As part of a wider streamlining effort, several little-used and internal-only areas have been removed from the web app. The features below no longer appear in the navigation or builder.
+- 🤖 **Builder AI Chat Removed** – The in-builder AI chat in the embeddable builder's right sidebar has been retired. The shared AI stack that powers other surfaces is unaffected.
+- 📋 **Context Items Removed** – The Context Items section and the AI tools that created, read, and updated context items have been removed.
+- 🔗 **URL Shortcuts Removed** – Project-scoped saved links (URL shortcuts) have been removed from the left navigation. Builder keyboard shortcuts are unchanged.
+- 💡 **Inspiration Library Removed** – The internal, Airtable-backed Inspiration Library page of example screenshots has been removed.
+- 💬 **Chats Section Removed** – The standalone Chats hub page has been removed.
+- 📰 **Daily Briefing Removed** – The legacy Daily Briefing has been removed, along with its project home page and settings. The newer Briefings product is unaffected.
+- ✅ **Task AI Removed** – The Task AI surfaces in task detail (AI assignee, working banner, and Chats tab) have been removed. The Status Summary now draws only on task details, comments, and activity.
+- 🔔 **Notifications, Inbox & Slack Removed** – The in-app Inbox, notification preferences, Slack channel notifications, and the Slack card on the Integrations page (all powered by Knock) have been removed.
+
+### ⚡️ Improvements
+
+- 🧭 **Streamlined Project Navigation** – With the home and Daily Briefing pages gone, the project entry point now redirects straight to **Embeddables → Insights**, and the top bar logo always links back to Embeddables.
+</Update>
+
 <Update label="23 June 2026">
 ### 🔥 Features and Updates
 


### PR DESCRIPTION
Auto-generated docs update following merge of PR #2145.

- Changelog updated in `reference/changelog/changelog.mdx`
- Other web app doc pages reviewed and updated where relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features and Updates**
  * Removed several web app and navigation surfaces, including AI chat, context items, URL shortcuts, inspiration library, chats hub, daily briefing, task-related AI areas, inbox, notifications, and Slack-related integrations.
* **Improvements**
  * Streamlined project navigation so redirects now lead more directly to **Embeddables → Insights**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->